### PR TITLE
fix: v1 pairs

### DIFF
--- a/src/constants/v1-pairs.json
+++ b/src/constants/v1-pairs.json
@@ -1,0 +1,18452 @@
+{
+  "pairs": [
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1qqfx5jph0rsmkur2zgzyqnfucra45rtjae5vh6"
+          }
+        }
+      ],
+      "contract_addr": "terra1a5cc08jt5knh0yx64pg6dtym4c4l8t63rhlag3",
+      "liquidity_token": "terra1veqh8yc55mhw0ttjr5h6g9a6r9nylmrc0nzhr7"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1qq4lemqmahjfhl68kpzx0kheuuvfyeu4ncnkaq"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ukrw"
+          }
+        }
+      ],
+      "contract_addr": "terra1u2g4fc0k4tq6z6lrdwhm4gry3q55dg8k9anjtw",
+      "liquidity_token": "terra1z0z6hz96au9lr027uedxay3s09ry36md3wpm0v"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1qrq5r95txaregxpa2c7mhf549u5jkm28rzmvt5"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1sez4t0zhe9d7lxlup0j8u4cnkz0qvzr7dj2lf0",
+      "liquidity_token": "terra1gpwfs62dyazxxu8szap927f5vyakyhaw9uqmcn"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1qr2k6yjjd5p2kaewqvg93ag74k6gyjr7re37fs"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1gprr80jpjqdueh0wpz9wgngzeqfmelqeeesxlv",
+      "liquidity_token": "terra1n6ds93c5uwe8shrsxn3ppv9e0u4u4jzy7crkz3"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1q93ws00plywc5prwv7mf2gdf7alhuqgk5w68lq"
+          }
+        }
+      ],
+      "contract_addr": "terra103kw7gde0cu8v7xm5fwm54dp7uyq8d58svtf8t",
+      "liquidity_token": "terra1q88d7swxfd36kcfeqhgdncjrht9rsh7c0a9vm3"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1q9ec5g6q0s3ncl9v068jkk5s2eae8ng3lxqtlf"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1au85utmuaskgd0uhgmhus35hpaca2munlzuhrd",
+      "liquidity_token": "terra19lttrz4lxk8pxaz8w650t3rupzz2avzud9lm3s"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1q96cf9rkt5aa4eqhun35d0u8pqwwyuqzlzjxps"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1057jmpyc8gmj70jkmuzujd8qu9m4huf0tqnw6t",
+      "liquidity_token": "terra1a6mnctp0yudvut27qmndgfl02a09ds7qn6p0me"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1q97dtnqe94vl5egn8rn482atykdfnrcayfcn9z"
+          }
+        }
+      ],
+      "contract_addr": "terra1aqd6qu6t505rx2tgcunslwtz7parvl2cy2ccn3",
+      "liquidity_token": "terra1tzq5r40udxvhcdlk24l3trrlydlu9my2rytpev"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1qxfhvu3w83azgs4ghk3v5z2nvmzg8td5gqfd69"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1240yffve7kq7xam0huv6scn9kdr688lflstkfy",
+      "liquidity_token": "terra1pxst9epy9cz5rmdh3d7f4lvch9xz4xp30xa4sj"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1qxfl4e8gjnunk0t3kq7a6ladu2p4cddk95s5jj"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra108a6djt665wvklxwhyr7lepvy5ej87c7szl99g",
+      "liquidity_token": "terra132njtndm2rjcn4x95tq5qm5h98smn8a7hnvwj7"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1qgt75fpc097an2vtqufx52anfcsu33n57wjkac"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra15czn3ttmcsn9xl72hfx6muyr23u8h3nhgc5e2y",
+      "liquidity_token": "terra1gp5dpf7lqmx46ravzh64a6azarewy3n8tff6a9"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1qgvd7llck3nfav7n9k2qh35zcsmjwap073x5et"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1kedzs6p7mc73lvnw87gvp5aa5azynafthhsxpc",
+      "liquidity_token": "terra1e8nn0zsqmlnhmxfmwe5qz5p3utyx2fljemtrya"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1q2k77qmnujgk0w89wx55rsnqxecz5wd86y2p2q"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1zjn2vpgstwl75qk0v7ae48yx3yd5layuy2s9vs",
+      "liquidity_token": "terra1nknmv45l04ft6t38zvw3xg0kqnwgqtqrewf2dh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1qt0j6rzqrc0rxpxxlyrvljmjkxrss2frsef5n0"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1u4uuvku6lupcwn2w8h3d4xmfedf6fz5x6xup8r",
+      "liquidity_token": "terra1423vexq03kadycrhzu4phqrwal8nrls6yzzv45"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1qv98rklgrdv89gvf47rrzx2lzehd43uwz2rus4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ds8u8qrqv87e5mud77up62rl34rtltg3v4w3tc",
+      "liquidity_token": "terra1maal7qmyn8vv4435wc3nx7nryu7swnj0n2v4dp"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1qw6sp3rjar2x7mfa0x4uj90ssemwap8p50f8kh"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ukrw"
+          }
+        }
+      ],
+      "contract_addr": "terra1g7an9lfz22gkv74238dhc2j6ymfp4jy0k55yxk",
+      "liquidity_token": "terra1yqnd70kvrdfazu7aplalwqdp3ksnu35fv9cv9m"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1q0q09duq6jsth9m0gfj7fpxlxwlj5fcxgchuza"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1kngr9srtrzfwz0y8ckjhx7559xhdgsthu44y2k",
+      "liquidity_token": "terra12wmaguvdvjf225ua9xjwpj5k5euy6nhtu334n3"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1qsjs0a02jmyfhvaeul4zax22sayx5e8dl8527g"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1gtu7lxdl878r02s2q7fx0thzfu852c3xhxj04n",
+      "liquidity_token": "terra1ekm4u8whtpzvna0arcxjpj5mx2qfcwku70nzgz"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1qsnj5gvq8rgs7yws8x5u02gwd5wvtu4tks0hjm"
+          }
+        }
+      ],
+      "contract_addr": "terra1y7vdguewgus669kcxjlwughyxtdt3kheys05q0",
+      "liquidity_token": "terra10t6a287n4flvjpvdwuhre79ws9plufaagdj4r4"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1qn4v9nnc2a0mdnkzl73rh60264gvhu6pxusz0r"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1jq6ud6xdljsrpgnmuhwc8e9sxjut5el6t5z9gr",
+      "liquidity_token": "terra1lfrpc9npxgz9enqcdswmealzvt96aae2qe20jg"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1q59h4hyxvfpu2hp3v39r8rpl4wykqe7axrc9rr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1xlgl3xvkha2y6mssy9s4qe70sq295825sdmt2q",
+      "liquidity_token": "terra165k229vdtpng40rhdfn3tqtqphwxeyjx5wrwxw"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1qelfthdanju7wavc5tq0k5r0rhsyzyyrsn09qy"
+          }
+        }
+      ],
+      "contract_addr": "terra1uenpalqlmfaf4efgtqsvzpa3gh898d9h2a232g",
+      "liquidity_token": "terra1mtvslkm2tgsmh908dsfksnqu7r7lulh24a6knv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1qm5jjajyv5pmap9687sgckc0j9hurlks3xzpx2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1t4ee4m2merzrmz5uwuacuhk773wq82g32v6zu4",
+      "liquidity_token": "terra1fvlf5y9uh3ylxff40eda4j60h52lnkthzhrsdz"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1qup6c3w83xjrfdtzujqkh5j8pcar96up8f0pdy"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra162cf20c6hrag6fhy9aqwaq9cvrp5lq5ffpvuez",
+      "liquidity_token": "terra1smzc7k9u3mnkynjvqclnz9qn7qfldj6waweh38"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1qlan324u6rsdevvc6ye3m02ump7dtp3z67uhqy"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1n4kt65x0mmynpfdgcwfz36dwws2v6er3eer6dw",
+      "liquidity_token": "terra1ua0ehzs2z7qq05qehnzvp44gev2w7cc7vnuyh2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ppuu0devppvm6d75sclj4vwh5ghwyx7grurlvx"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1pdstq4vkeftz5kmvwk5dzaytpesv5f3kq5q6s5",
+      "liquidity_token": "terra1f0tup70r7ycf682vc9h65p6g59jk8eefvy67qn"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1pzjz4uwf7hp4sy9zl66puehukwass5xz4twxqe"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ss72jvqq9c9l7g743areqelmfsh2myuyej7dsl",
+      "liquidity_token": "terra136zdk856v4gp2lujauc8834cc6u0h6zaxyjqwn"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1pzjd5axw303jt40l4pmakfa88d0jpjf8rpmj8n"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1axd3wejrvzx27sn54yjlxlhrrr49zphqw9fpn5",
+      "liquidity_token": "terra1d0zt56yn4lx24ewxy3n40ry6jg7e7xvrp2uhpq"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1pr2swnalac9ny993tgvtcfyhe4h9cuqm3rdmnf"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1quz6cfd40l6qsfjyrmu0xe5xsnufg6g4rr00a4",
+      "liquidity_token": "terra1fd34ray6t095g3rnj9yskjum0kglrym44qnmra"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1p9wk5tns7jagwch6cdasgd753nzfj544v75qxr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1vnpmtslwxr76ar3wmjy8jlp6c5y0sckvh96esl",
+      "liquidity_token": "terra1hmuhs99qw938edq07c4sguhnpmwaulxjmufm9u"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1pxuknzmg3kup7790vjzssjjuelrq3a3ys4aml6"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1vvvpchwf7rac404q070x2d0jr20l0sxkcgv8y7",
+      "liquidity_token": "terra1ppaywpn8kyde0c0xngdfagjyq9l3jwudmckxw2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1p8y9f7dpmyzy85ldv3k8xccuw0u87lsn9fl86l"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra170lzdyflaamashcqkst23k9ew773dtg67tfu5m",
+      "liquidity_token": "terra1t8qmg9p583jcp2f7uuhga73yh7ze0u4ny7kmzy"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1p8yhtrp8ttcrrl90kqez0602yl2sx2gvrw4h23"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1vau3jl4x6206qx9acy6pya4vk8utv5gex0sm9l",
+      "liquidity_token": "terra1xsfjx985rvkchme4wws0fjt79x3wylmjyhvvv2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1pg606jw68d9mnh9czrgm7celc3rq9x5wrvj7gl"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1nx2auchhaq346scypzrksvf5h60sywwygcrgvk",
+      "liquidity_token": "terra1pkfpkm4cjd4elhp4kwt46anguj76vkh4azyfxw"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1pfynaj6mslxnlekjx7f6rxgfastl46c4hg3kg7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1z50d83kx5dke2fw2wtrs4kj6ae8ga2pe5vhwl8",
+      "liquidity_token": "terra1pce629yhpm8n8rxe2va4a89akcl8826fgg7wnr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1p2enl6vfmhdfj7ud32p3fkgns22sg62ls9mh2e"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1q6h4sgkulkxl6tq8tafadl899sc88zp4dj6yd3",
+      "liquidity_token": "terra1xwq5m8nkjkcfm2thpr0vesl4g9frqzdqwf8l6h"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1ptdxmj3xmmljzx02nr4auwfuelmj0cnkh8egs2"
+          }
+        }
+      ],
+      "contract_addr": "terra17mu25k7a2lj7pn8vjgtc5vjvah6gkt6njgh4q5",
+      "liquidity_token": "terra1yjvlgj80jkzwakqv65tzfwctdehqav4jujgx37"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ptmrg9j7tcjphzejzlygehaxwtzrr6ywsu72qq"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1dwsngznkraae33wufcz8qu4rd83elrzn9g03el",
+      "liquidity_token": "terra1zky7u7ynn6m67zequu5cgh7jefadg6ux46a22z"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1pduqn0tpqce36ndwcv6z6xjlnujdddl6pedz9y"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ck5vwpsz9nf95c7t84jjwfgpxtcnpj23aka3ml",
+      "liquidity_token": "terra1l46txnnqf0j4l7g6630dhf0vxqhpxyzzadchfj"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1pwu44z0gwlfqecwxuxh6kwn46d8930x226drxw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1fzjflxpv8e0d8ue7hu7faap6mnd0ckamwje5zp",
+      "liquidity_token": "terra1fhvkxz23x2w5kgsag0dteecwmfu9zk9l0frurh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1p0yttugxt3h2zvs9cghysmss3um6dp0mzt9vwd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1w94sqf77fzlv9eh3fz8j5kmcdv2x230hnz9gj4",
+      "liquidity_token": "terra13tlvdmr6x6fqddezpde0d3aadk3g6ye7u6l0ud"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1p0w9hh9aea5mg26mjnx7tl695ldwxfksvw4yn4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1qzrqt3phmawkrrzm8x8hwngz26nrpdgpkw5pmd",
+      "liquidity_token": "terra1mejc99wk4nnz4wfxdrak7rgm0wn2t9vx2ty6qx"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1pshxc56zwgm6j78mhjgn2rgkj5d32aa887l7j6"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1w2aryua8k5s0a27kt9v8662jpsh4wglctu9z3h",
+      "liquidity_token": "terra1jx0n352z9jhxsu0ung276fukdcn64vvyujyp9u"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1p3z96mc9gr66yruc3c0v73u0e574kjpgeledm3"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1tcrpkhxurjj2qcl5sksxs4cqc8mgz8dp0kfvhm",
+      "liquidity_token": "terra1v0qd7s259lr83t7qp8aknmn6jeq679u4xnnhpz"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1pjnfhsvg7g52hfkdegr4apz7ax9x9xn0n2eayj"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra13vkjx8agphchqzlntq7qn3et86ev4nga6uz9dh",
+      "liquidity_token": "terra12ms0jp4kt9r3s4g2w5dphu8vqf027x6u0t9z25"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1p5k0vl2g22zv0r07fxm627pf8u5frazevqgkw5"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1gxxu7stjnshv7c7l87upcs9pqv7n6k07qfr7wj",
+      "liquidity_token": "terra1hx9erauuaalwsexsg8jn7fmyd3n4g744dj59p3"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1p474w2vpsz5g34pw947yjpyx3c5uykwffmrezs"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra16xjzlwj6kkhcptm2a2mkapcjezu6edjgsu92c7",
+      "liquidity_token": "terra1up85kq9armtk6fr7rhwqsu45u633lc442erzzn"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1p474w2vpsz5g34pw947yjpyx3c5uykwffmrezs"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
+          }
+        }
+      ],
+      "contract_addr": "terra1l33kmly72lazdqedf0smfwhneyky6jqsfwqwgj",
+      "liquidity_token": "terra1ljawxphkj6c3ggxlsdsm2zkp56c620jz28z07z"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1pkfzenexjj6ne68xv2g9t8387s7d6z39c60ghr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1c0g493amwrzx47zxa0qcvrks7wyhmqkpsf8u2y",
+      "liquidity_token": "terra13mehc6ldhs2sryy388tuqn5cxq573gdhrq0cjg"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1php5m8a6qd68z02t3zpw4jv2pj4vgw4wz0t8mz"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1w0p5zre38ecdy3ez8efd5h9fvgum5s206xknrg"
+          }
+        }
+      ],
+      "contract_addr": "terra12arl49w7t4xpq7krtv43t3dg6g8kn2xxyaav56",
+      "liquidity_token": "terra1hg3tr0gx2jfaw38m80s83c7khr4wgfvzyh5uak"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1php5m8a6qd68z02t3zpw4jv2pj4vgw4wz0t8mz"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1wmz6qgayzam40lzplz55mmss8xadcqm7mx6f93",
+      "liquidity_token": "terra16x0yfryw50tr8a4mhkh2jv2fccdtm8nyavcfxe"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1php5m8a6qd68z02t3zpw4jv2pj4vgw4wz0t8mz"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1v4kpj65uq63m4x0mqzntzm27ecpactt42nyp5c",
+      "liquidity_token": "terra17pqpurglgfqnvkhypask28c3llnf69cstaquke"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1phkvke3wcxqtrm773ur7e72t80sx87rg88ef08"
+          }
+        }
+      ],
+      "contract_addr": "terra1pfkuxrzykqe50vlh426rlhvsylhsmhwrm52uf6",
+      "liquidity_token": "terra1qmda2mu4jgyvdtj756z97uqzch780e2wdr7m3f"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1pc253zfn4zns6awk7eks779uk3m7dna7y4cmlf"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1h9zcqxdcl89hwvgxh2v6l3e3lfyguawxcvtasw",
+      "liquidity_token": "terra1x9qq5yerv3wpq5f0hlhj84lq7ulpmd88taxvnd"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1pmf2x6gp8u979q672lkkkruuhe9zarxyu5w7t2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1h9jyaf7wttw6txdy64608wc6k998dt2ny8zjwm",
+      "liquidity_token": "terra1xfq07tcdep6lujx480xqs02q5tk3ka3p4l2m8d"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1pmcr4gjjsu62t2d9e33q6d75sydrhnpt37nayz"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1jx3m7swaseumanezk3z6r73cptucc9dqg6hprk",
+      "liquidity_token": "terra1lqedtculy8lxdpdyy7pagztkf2aj3kggaf530s"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1pmc29k34jrv96wde08znhmjq4v2rmzy78y6dhg"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra15ledqp3plgp9gqkalkf9p2skdg3kg7l7zd7uhc",
+      "liquidity_token": "terra1peq4pvfc0jzpgdnutdkpu5ad420zyr9lyrqr2n"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1pmmdfnmhrjnywsgkd6xplgp8nx03fxm6ygma09"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1c0hc7ncedxaps2hxl0qazxlh79g4zdre5geq4m",
+      "liquidity_token": "terra10fh39v2p59x7pcu0659r7pq7zdhkwp7hr96cca"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1pujanvsuhqsqf8vc7r3ky9ghr8sgeg4e3ngjun"
+          }
+        }
+      ],
+      "contract_addr": "terra1hn8m4250rgmtpx04uc75sfvqsyvcj4g9fdrmlg",
+      "liquidity_token": "terra140jj5n8yd52ucvntzfh02yslfuys3kxnd47lzr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1pafrxwl8ur3jzjgw5qhts9vku68xsenctgqvkq"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1r909kfjzeuj9nhwle2d6kg5jhn2af8j59lcsqj",
+      "liquidity_token": "terra1tc3llqz3ckh4ahepmv4sdxc3s4dvn9vqxtax9l"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1pamyemqvkj8ws0easzq9pkl8usnjt424ddraff"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1jgrs4fnevw78q8rvutwyjzxhyy5fzqwtft6jea",
+      "liquidity_token": "terra1kw6qk3wpdzj7aklge6yegqjlmnrm83248v3vwz"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1paulfn369vuz6s6ty65y56wj8gnamzpdzwk9x3"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1fcgvdqe2dcgr7x2a9w3nfc0nhjh07zggzdlnfm",
+      "liquidity_token": "terra1de0x05wwqt9yn8lpd5phd4r0pgu2zawcc4pd28"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1pl68znj0kkxe9pwp2w9tc500y4rdk6878mrfy3"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1w2dnjy73mcd992k2awkx4rwazcs35dv7lf97wz",
+      "liquidity_token": "terra1tfzqrt580vzr4nvn7evc6njthg9audsx95dycv"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1zqyfp259xhhct6q2alp88pke90qrxgr5u2zc7s"
+          }
+        }
+      ],
+      "contract_addr": "terra1kjlt8zsdvmxaw63u38krl658zunaj9hzxwknqs",
+      "liquidity_token": "terra1jz8zydxlar694nqhdfjc592c9lddvxyqtn0arz"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zpp3fdnpkrhpehjxvzz3wwwujmk0zxw5h4y0rr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1wpawa65459fzfvf244rz8c8q56ampvpkjnpe6f",
+      "liquidity_token": "terra1q84pz7rtnmjr02uqkpjt75r5hgcjxf0l8qpwvy"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zppj8uz7w6xz3ktg6nj2r4ntzzypgpcy07t5qa"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1l5lxw4uucaserz6f9g7av9ejyfyac5jpw94fh3",
+      "liquidity_token": "terra1c6p2vl3xcc2ggufa0a9mkn2wjh9qy0v8y9zxha"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zpz6dfn24cnykwausjt7qwfdqf87kny0trn94k"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ya6tdm86gequ9wc7lusx374j2flgldv33426zg",
+      "liquidity_token": "terra1pl7nft4helwl8xt3ev0lknk4rkhrceve4s8lk3"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1zp3a6q6q4953cz376906g5qfmxnlg77hx3te45"
+          }
+        }
+      ],
+      "contract_addr": "terra1yngadscckdtd68nzw5r5va36jccjmmasm7klpp",
+      "liquidity_token": "terra1cmrl4txa7cwd7cygpp4yzu7xu8g7c772els2y8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zp4xkexmng539vylktxkf45hxjg68ufx673x8p"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1v73xl4qu05ahep8c8flf83vvrr437fftdxwn70",
+      "liquidity_token": "terra1p62jdngzanleq5wrwehehwl05nkwzhuuld6nae"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zpke3t4nprnh4044a4n97hwv384v9vff688cyj"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1u9hhdcqsd25q72dqme8hp8jkq6gq67vtg3rdq7",
+      "liquidity_token": "terra18wnz4a622jvlhk5xnwuetk93j5xrkrpy23kqp0"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zzfhavsjlhhx42rnjfvwk6u7taplh4qxqmhgfa"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ejql0hjel8s7ywxansv3svrrv4hv8t7h0803em",
+      "liquidity_token": "terra16dv8v3v52s7ktxdgltxz6yje67xs8c3azaa9g9"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zrfd9hf3z6kwewxrt3rluzdj5d7ymzxnnptc6k"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1l7l9grndgnjagmgm7e0wf0aglwrj3wtzgcdtz9",
+      "liquidity_token": "terra10fmk0879fn2hm6728kgc40ytkqgn6cdxfnzyty"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1z9yq8l5fn7y5msg37rx2p0up0pgkf52ml4uv0q"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1y0cfekprajjqmz9jth6veq8pe5t2qurwg9kk4m",
+      "liquidity_token": "terra18vvfrdsxefmheygjlw2d6835p969snpvm2xlar"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1z8ta6q6tfvp3sec0f4yftt8ew656d0x8zhgp66"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra12qjaagzpkz28ngtpg5ugelsmcmtl7x4w4nuuz0",
+      "liquidity_token": "terra1uyv9trfhqk2wf9m6x5ksm7j4yq9hfemr5swqnh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zfqe2kf0kh8mvyy3ksa29qqnkhc64ncffufg7g"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ufzll076stnpmlmndlss4uezlq58gmwc83c72n",
+      "liquidity_token": "terra1slr9qj73j3gn2muf94aysdaeex6ahk5ghq7ehp"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zfvr6uszt8khnf4damxrujfkhgl0mep0khcs7w"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra156h9adaua27vcqtguttxk6pg3st07nrypcmy6f",
+      "liquidity_token": "terra17a0zdmq6xf9jgac89y2nyqcytkcchnneefu8nc"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zf00lfqwe6ackx0lcl5ys6lzmdhmvmn6sz2rh8"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ek3g47rves5tmulz3h7twl04fawldwhdr7pyxf",
+      "liquidity_token": "terra1gj5azdr9y80d3reegwumpz48ww09sqqym68vrz"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zf5jn0nsureuqaeqmj4pwkrtcm9m7rmlkdjxra"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1esaxnyzts8256a8afsgqsghvm263ngzr32c9km",
+      "liquidity_token": "terra143v5xc8zll66xq8zljxulacqylsdhlzwaraz02"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zfcfvsw9m3gzk5l42cek0ukn5g4dmd8gl4lyra"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1nurx5e8lh8pfg8hnxw35duczvsx6lhdjrxy5e6",
+      "liquidity_token": "terra1e6kja3hn04rhc8lslkdk63ry0gspr6zwufs323"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zvncquef39sne2adlvl3xpzcsge0fypakp00zx"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1a8gkw3a2kc05wrnqv2tmvl0h3ej2gwenlakakh",
+      "liquidity_token": "terra1dchs757cqkjarjyl3cwk37kcd9tkvhkuypfr2f"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zvhvg09zeyl3txrc7v3crnqnnwc0d2nvgxvdhd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1a2k9k9g5gyuats98z69ssk4aqjt38a9z943xd9",
+      "liquidity_token": "terra1z373t5nj0jnh0tjr7ljpdwgh046gq3ym9vk775"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zva2uegkvwr03p98mdaam4dtrkfxxvu330zwaq"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ukrw"
+          }
+        }
+      ],
+      "contract_addr": "terra1dq27eeasl3rtlc8j3ls5yz8wurnksahj240tsr",
+      "liquidity_token": "terra1prswk9yyayfkkq99fpaz5zs7h0lhcpsqa4swj9"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zdpymdwpyg5gj5ye4uvr0mqmxw8c88k5vqegfr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1rfdh5rephrd37ga0x5cry9lek8eutf54umkk04",
+      "liquidity_token": "terra1wq2tmhvx2yn3zqdah26sg3xzlaaxwd3fhsnj2y"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zd6let0zg0xjn2sestagxv4ax24a4ml6j40qdr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1fdwsevq7skhfq93zkg0xxr6zrv29aqupw2fura",
+      "liquidity_token": "terra19tn6v77xf2v5tkd0g3dl5wqvjdh8d0u4g3p2j7"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1z09gnzufuflz6ckd9k0u456l9dnpgsynu0yyhe"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1fd9hxy2ajycyywzgvu72mj0m75myqy75dwuhtn",
+      "liquidity_token": "terra1u2ksckpcec73mmy3gl3l2uc473vl4vh864npt6"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1z0ewtcsaskfmsp6ue59skulunehzv27ndw5yl0"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra13yc7dcphaxpgd538msys7r75d3lwa5mu9u6d88",
+      "liquidity_token": "terra17vddhyh8zulk4yx2zapsk9z5y5r5mjaf9w6egv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zsaswh926ey8qa5x4vj93kzzlfnef0pstuca0y"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra12897djskt9rge8dtmm86w654g7kzckkd698608"
+          }
+        }
+      ],
+      "contract_addr": "terra167gwjhv4mrs0fqj0q5tejyl6cz6qc2cl95z530",
+      "liquidity_token": "terra1t4uuc09t4ld560vg2k9w2f5m9e5trftnym50zj"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zsaswh926ey8qa5x4vj93kzzlfnef0pstuca0y"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1svequ729grnrj2d8x609e45axajrdjz87athfh",
+      "liquidity_token": "terra1gm9lk22dcd36c9s86pqdql6ll0w2c8tpnwye0x"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ueur"
+          }
+        }
+      ],
+      "contract_addr": "terra13nwgt8kxyat5pt70faxnm8dje0c67hwsp53d5x",
+      "liquidity_token": "terra14kzy8xfmzq8pugr6fp92pcer7nuesyyeqt8d9w"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1m9wn7rpc570tsgfuk973m4c8u52k8gmks4f3ej",
+      "liquidity_token": "terra12mh2afj5mpsncshgm2pnwwp3svaqwattvzjaza"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra19slzdkvt3kekyq4ydp3ky4pjuus5lmedafkkzs",
+      "liquidity_token": "terra1nrn8m6laft49628jr4t9ajfj4um8r7nzedw5wx"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
+          }
+        }
+      ],
+      "contract_addr": "terra1efwf7jw3tgyy7uqx3u8j9p0kpl9ts39avgnzec",
+      "liquidity_token": "terra1kyyakqzf92xsg0cu8j5xwcjnzmuxy42nygdgpf"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1hj8de24c3yqvcsv9r8chr03fzwsak3hgd8gv3m"
+          }
+        }
+      ],
+      "contract_addr": "terra17lrhh6zh99g2u2d92y77xn8sg3j4sp9frkga3d",
+      "liquidity_token": "terra1fwj38qsjpj7huatrms3ptp5spgnmz03ghmdhtw"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1z3ejshh0vwkdr35wt9eyxetsqm6mnraya8myxs"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra139j7k5lfre6kwy6lh2d37tkvyj07h7aafke3qj",
+      "liquidity_token": "terra1rcdp0wd0qww62h69kex8f9c99549902dp7huf6"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zjhsuvuy5z7ucvx56facefmlrrgluhun27chlf"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
+          }
+        }
+      ],
+      "contract_addr": "terra1qthlsaqccp8mxr2z4vvkhf5ynqjl86ccxg0pqn",
+      "liquidity_token": "terra1e90arspgwmd27x9tt6hp7hwpfjl9y5he4sc8ed"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zn26hzdegq2c9qa0etqcthk2kjcr6cqeaud7q9"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1st3tr5ppd3cs8zfl7ygqtc50y5thn5h6chdpmr",
+      "liquidity_token": "terra1qqecag8xppl7faec4rrxp5v0vheex0s9dtvhte"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1znvnhtdxxsy9vkvmqv85nscujeqmmtjlp2a3wj"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra170uexnuckv87q2fl392269m6nt847fczs0yzuy",
+      "liquidity_token": "terra10klhxjnafqnt5mu6jugrcqs0kaepprmf425c8q"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1z4pfv9rrm53tg72cwkcv6ddvd4x6wcce43nua2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1yrnzye0jfk23eqmecrckgshv70clmtzpq7shl8",
+      "liquidity_token": "terra1gt9cpvms742m7h3s03d5fqex0czjpcp6zt7pnx"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1z49dpvu5g4st7t4j5lsaxaq7v9u6f390m28ap9"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra150cw99qkvwafxw95vyef7d9upswsmr2wf7xyh7",
+      "liquidity_token": "terra1nu25e6fzs456lh27gpzyq4gn3vpedf7cut5020"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1z454qecteghkd8m3shgd48cdc7j7vtnsgxh4z7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra18f063y03tq2tdj20gcm7w5t0an29m7yex0cvy0",
+      "liquidity_token": "terra1kr5twwkkdr38wa3t2477cmmrwwpjuggxl962y9"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zce4mxwwdyk04txa2f3aqepzsq8jy7ca50gn8w"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1wvhxy96s86xk4mynuqggxhm46jaq7h30k8gphu",
+      "liquidity_token": "terra1uz6m6h6seck9q870hnc8g2t8rxtzn5nwg7txts"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zey5xuv48yfjf9y0v6zkyfdtv2du5kau2kdrna"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1cvur5qlnaqulwt987f2crk8ccttlvztuq9w66a",
+      "liquidity_token": "terra1wrwxmmea6nxktx09hf2f2m5m0473wnq9lxhn66"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zmjucf7ht48535c8aeqjm0yfdxtqf89fp5eve5"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1wj3ur7tqxvzcmxagcz84epla9c5vgvnrf43nzf",
+      "liquidity_token": "terra1v9l5ckkeg66zjr3zselr9f6fhts5vn5p37nqdl"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zucgllq5ddqkfgsyjr7qnrfhymu0y4rgqsfyet"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1lw2vz28ajmdntvgfz95rdgljq4gc4qw90wc6jm",
+      "liquidity_token": "terra1y0ej8fdyvcy4736m02eu8d9ftr892de78dypwp"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1zawrkv57eh7rne45zjta7s876jqc59slrev9xy"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra17vk5j4mhxnpl74xmndmyjfma3ynpef6kj7jhuj",
+      "liquidity_token": "terra16t34llthsfwdjazglwamhv4f20f4ux4wmm9zzy"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1rp3mdhrwxhdlx923t2q50f0n6z6660z9yqghpv"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1yg74xslj94r7cjweu8gg6s5c497vs2sdd6zwgy",
+      "liquidity_token": "terra1z36hglaqjgv867xr7e4jsz32pr7mcstjg2xm6u"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1rr0vr9c8l4r2rpkgezknmearev6d30tdvkxu52"
+          }
+        }
+      ],
+      "contract_addr": "terra1yn2gvn8j83mavn5c3z45ne5k9l7rr96km64gqx",
+      "liquidity_token": "terra1df07usq3rsac4j3lrkduwnj39njj6n782z494v"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1rrek47kf0t968g2jcg5ww8fw58n93jkclkk4v5"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1equxgxqvhr766y5sp2cvez089dhczraya8eapn",
+      "liquidity_token": "terra1rtkrppjasmh9ha9aj904kwu4jyck332tu8w33f"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ry60wuc8a7a4ujt3tmrp3upxzf6a4awj88eys3"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1867v6pwuaachav723ukq9sajaxgtpe7w3aefm7",
+      "liquidity_token": "terra1jmap9tuf59k5mmr5shgmywqfxmcmlzxusn49vl"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1r98ydsd3jdjpnq8hhcdd5rnptf2l0r7zvaxu48"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1x6umr9xk86l37gxsayt4fz26cku4dya7qr2gtn",
+      "liquidity_token": "terra1t46rhfcgqpz9xkx33qpzk55yudp7wdaygj7yfw"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1rxfw0y02hfhnase727dqpn8kn2uu49qwrwul8t"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1uytrvr6hqkptkkyesmf78qgwz9rhhcsxul9zsf",
+      "liquidity_token": "terra1eqxhcr0phgthnjyn2dseewfg28pqp97lv7ryym"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1rxl2tv8jhv3rkhnesashgk8dwuvfa9kdzv36rp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1xf5x5gyg5x4n22v9tyv3mtxzxz86hmpd3jkfju",
+      "liquidity_token": "terra1aglpvqsrgcmwy4v93uezlmaftdqu3qvg9htlcc"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1r8ak49p50g76zamn25h3u7lkmn9n4maq2k2le2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1djzkg6ghcwmlkcdxpqq7lw42e695ulzljrvavr",
+      "liquidity_token": "terra1u5qgpemcltd5y0mzwqsz44wws5z00zyusa8w7z"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1rfqm5zwkep3jk845nf565yyua66uj654y2vzx3"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra16jv42g5t95zj2rvddzqvvd5sjvpvtz5fz5sksz",
+      "liquidity_token": "terra1z038v5j6mlwluahjjy6z73q6ckq6rwkllj5xue"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1r2p90ur2zy8javfhnf7ejdvzac60ax3wcvkvxz"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1xvvrm52lglquyp62kgpcww8489v4wqy9us6skq",
+      "liquidity_token": "terra15ctvv29qxq5h2dmqt60er08smq9547pg49j0rl"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1rwph273axfefh8gh57scw3jfm7kn4s7t5hlu03"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra14u72dnthxnct8gqx8zxjpqza8dkr8nlc7w2dk8",
+      "liquidity_token": "terra1zrlt4v8jzrsst0zq4ug98xaz0rmerpajff63yf"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1rwskqpnk03hrh8z8rrprzdluxhzc5udycdn5g4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1umst8uwnuvd42aecxzf26jyy9eutghxk4xvlkn",
+      "liquidity_token": "terra1xuqzklvz6chcpjjmy3tfgsrmytv8wtf207tyc6"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1r3u50sue9akjnndgvxm7fe0fy5jdtnyxwuetw8"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1jvq9ufp4vvypp86hl56afvjn7jqgxxu30l5zhd",
+      "liquidity_token": "terra19yfdxaw7qexrzq8lr8mjs478uu53ptmdmgrhad"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1r5506ckw5tfr3z52jwlek8vg9sn3yflrqrzfsc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1jzqlw8mfau9ewr7lufqkrpgfzk4legz9zx306p",
+      "liquidity_token": "terra1znt9ness8ayxvpmldqser8ess07engetmrxwfd"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1r5c53q49wu2vqerecdvua2zpvy9k8vlw7cnx25"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra10zgqdcpxhj0rgvm98w2slu9z09t8rk4fs5r8da",
+      "liquidity_token": "terra1ces0z6rlujzjw2f6axxjxaqav8v8kh8tqmhpqk"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1rkn2d2yc0946a0gx0w0hwf3l2j32ve39egsjkd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra18kwhhu4fxcc2x7lwtct8jatwv9843n6de33g6r",
+      "liquidity_token": "terra1f32d5xv494x2sy7mugu6k0hy3jvqu7dut7zk2s"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1rh2907984nudl7vh56qjdtvv7947z4dujj92sx"
+          }
+        }
+      ],
+      "contract_addr": "terra1xskmucgxkzf3quwry3dazerw74q4aqplu0vgg4",
+      "liquidity_token": "terra17rm53s5vhjpfrjkhappmswczcmhl8zqdwlfwtm"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
+          }
+        }
+      ],
+      "contract_addr": "terra1xly8628q4w7ytfq2dtxt7c39knnhqnaj83zzsx",
+      "liquidity_token": "terra16xmae0686wrzmqvrcf4clsy8yyv6r40ddhrd30"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
+          }
+        }
+      ],
+      "contract_addr": "terra1ws34kqg6kek40jy8amdz7j4tyzqx8cenz40rem",
+      "liquidity_token": "terra1dy3ylyzykr7ykl0kyruuf5edmvqm4lm5y73n9k"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw"
+          }
+        }
+      ],
+      "contract_addr": "terra1prfcyujt9nsn5kfj5n925sfd737r2n8tk5lmpv",
+      "liquidity_token": "terra1d34edutzwcz6jgecgk26mpyynqh74j3emdsnq5"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw"
+          }
+        }
+      ],
+      "contract_addr": "terra14xpe4dx4xt3cxmyhlnnm4rhpn3umhw0peyva5u",
+      "liquidity_token": "terra1h0y6p9c6njvagcd7sar7kazpx4djymuzft3jns"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1aa7upykmmqqc63l924l5qfap8mrmx5rfdm0v55"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw"
+          }
+        }
+      ],
+      "contract_addr": "terra1kj8zfkf3nsc2wcad7gkjjza45qnd5lgslpz4pr",
+      "liquidity_token": "terra1lsx5sjly4yc8szw6w04cwhp7tzmlrssh2g7trr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1rctv4sdztvscdxw890us4ewcuvh77t8wydxkxr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra19ujj2teuw6m45v9c2wk33wzl4mjr22jlw3nqrs",
+      "liquidity_token": "terra1exs7v9pvkl90zjyd5h7lu26hzszwczfsedc3hj"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1re7as700g3gels30zak6ctnjtsjhhc6vjr93ms"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1wn34gxq3jyg9qtjxjfzlj42jzjeegvgymdld2c",
+      "liquidity_token": "terra1wv36wfhmlkxvgczn0c3ta4djx7u5fkvcz8fpgn"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1r6pcn0wdes6lrtxty3xu253c02grcvuxmqg4s9"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra16aunxdkl5pu0ftz8q7sgapmwtlls078lj56r9e",
+      "liquidity_token": "terra1myejqyh8u3q5prx6h8p9hplswdhwtuxuk5stc4"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ruz2e26humerfnd9uhurc9766a4at8x8e3m2e4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra19mzvauzmythgn8d8vl944vczh5egrlnqfqygke",
+      "liquidity_token": "terra1gsrzxzh5err6vsc8e5qseam2x3gx5kuavwuuzq"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1rumme3vcguv9ly60p53j6wg5qanacfa9nl5uyw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1feuaajpy0yyag7zsz2w2yxst6faeemn82mlnrf",
+      "liquidity_token": "terra1gpavmsf3snhltxnf7n6nyz2ehyswtflhsqk7de"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ra0ljqpyt59k7z4xrx93ef5jvpy67f56lhudf9"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra14gsl8tl6pwe4xmtuc4c78w356n66klmh8xn26w",
+      "liquidity_token": "terra1uasdrlm92p47mvgtawcjmn24ut2a44mykyfz6j"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1r7qpupdxkkh58vw9u8y9n9wjp6d9lr08u39j0z"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra10vatx9jkv4lcksugsrkajstw2duh834j5psxzs",
+      "liquidity_token": "terra1js00fmassgas3hvnurd5va8u72el0ehvjxjw2f"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1r7e9a5su34ne07e6v0r7n2xp4h6tjkxc8j2lz2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1pcjl6ammvypn4z4srs9dgzd2pgqvsw0xy85fj5",
+      "liquidity_token": "terra1qt6nek5pe7l0l3hwcarjd62mn24a6v7kz8zkxf"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
+          }
+        }
+      ],
+      "contract_addr": "terra1q00r9whldewsktqne5sux6gtaxn2vlfvu5geej",
+      "liquidity_token": "terra1f70a00zl3uas3m6sjvw72aezslznedhuy46dfs"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1srp2u95kxps35nvan88gn96nfqhukqya2d0ffc"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
+          }
+        }
+      ],
+      "contract_addr": "terra1rxzs4rs28rx89dt57nnph6xz8zmycf5js2d4ey",
+      "liquidity_token": "terra1rmd0dm804l69m27fzcgue3v38ckhfg6n04gw8a"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1jkkt5638cd5pur0u5jnr2juw0v6hz5d6z8xu8m"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
+          }
+        }
+      ],
+      "contract_addr": "terra14hpees7gp0addrkgavwpylsr9tnzg57c0vdxav",
+      "liquidity_token": "terra1nvhkaq2r992j83gnxgjwd6u00a86zdmje93jvc"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra16gqgpuy7z64chzz3su2xugjgrhuj3h89wx2z59"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
+          }
+        }
+      ],
+      "contract_addr": "terra14c8m8anc8u9llaf2tq0d80986vmeprehkrwpnq",
+      "liquidity_token": "terra1kyxge285zakkmet7fyam99f39xyhkh8ntw5gf7"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1l670q2m9j3npltmsqe428mwu0msw336m8jtq00"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
+          }
+        }
+      ],
+      "contract_addr": "terra1ayqus392c2fzs4mgrsnlkzjaqfd5efla72el85",
+      "liquidity_token": "terra1e5ydr2utqs4skdetw377ndqmgn07hzrdwc0t0m"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ypgjelmtp0mv5akzwmnj5xhukhd3fy9gd28wpj"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1kngrh3kmwngq7t4kcnqdustp3qurvenrhphyxa",
+      "liquidity_token": "terra1d49ve0m99xz250uyj848yd9sgwuh5vw30kxm9h"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1yrch507vhsmd9rue6q3v8pz4pe445jl09nrvz6"
+          }
+        }
+      ],
+      "contract_addr": "terra1u475wh425cs3wmgjqn4fqxyqpv7qmsnw7qs0sd",
+      "liquidity_token": "terra1mnj6zstfk2ne0htcre9cvjv9ut0zd5t95wyagy"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1yx2z4j3wr55k7jns06qhn2hsw6agskvcke6zu6"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra166j8s9pehm35egpmdfkrvlqj9a4248wqcg5s08",
+      "liquidity_token": "terra1q7pc75pf453crpdkhh8eqkg77chuvvnqxuxnmu"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1y8q4jk5xwag3sschctduxa43eesupjkk6kr452"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1f3tdduzpsdrg33x6w8cqmzmyytnmhzcvwnharl",
+      "liquidity_token": "terra1wl8puq7gyxdu2nwqc5xym2gs5836mx4980gpmq"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1y8w753jk2x2j6f7a9ea30xc2qk5esharn89sk2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1fehg72ukrnmt56evclq023rpefzjmrwre9k6vl",
+      "liquidity_token": "terra1mrs4cvfg8s8anlyvyf9ttfv4uf49p4q0qc44ws"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ygrhf4zv86jp7hnyl358uj42llm75gt7w8e9s4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ct767uq6h75duwd0jl6t9lxt3zn3wvvnec3snh",
+      "liquidity_token": "terra1lkcazx0hn69qsw62tyhj6u0svsnepg73vj553h"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uchf"
+          }
+        }
+      ],
+      "contract_addr": "terra1zxcmcjurg5jrml8kv2vhupdlfqn4n6euasuc5q",
+      "liquidity_token": "terra198ngkjucgje5xrrup6hwuslh7jm2ks6r35gs9q"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ueur"
+          }
+        }
+      ],
+      "contract_addr": "terra1h2mpd99j8mcuyjcxh2wa5xsdkhwtrhyucsyrzr",
+      "liquidity_token": "terra1ec352y2dlwe75kx8px3ncxpgc6j46cmlsvn42f"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ugbp"
+          }
+        }
+      ],
+      "contract_addr": "terra1rq55zs9w6s24wmlmd540j2q2p6whanurfj26eh",
+      "liquidity_token": "terra12r2ux466d9r3v44dq6zvj8mrutpslz9xrqv9vu"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra1de8xa55xm83s3ke0s20fc5pxy7p3cpndmmm7zk",
+      "liquidity_token": "terra1cksuxx4ryfyhkk2c6lw3mpnn4hahkxlkml82rp"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra13htj4202asg8fdmyq002zm53j7h4my8q4kdddt",
+      "liquidity_token": "terra1q4qtr2pzzqg6ukdymazqux9vj9w3t0lqet0ygd"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uset"
+          }
+        }
+      ],
+      "contract_addr": "terra10jy7a3hhma3qdym3ne4ngulm9ywdrjaj6k7y24",
+      "liquidity_token": "terra1d3e3crn34pev2mq8vuz53nddg68nytg92unjs5"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1u553zk43jd4rwzc53qrdrq4jc2p8rextyq09dj"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc"
+          }
+        }
+      ],
+      "contract_addr": "terra15zv6wcyqkw9ye86qku2yesqdgpr9qsz2xus4yx",
+      "liquidity_token": "terra1ylqfv4ykp65gxxx5e39qe5ahzm52f20u8equxd"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc"
+          }
+        }
+      ],
+      "contract_addr": "terra1qyynd88qccpjrdn4yghhf8n9dm9msayrtqwwva",
+      "liquidity_token": "terra14qrt27zl7w2eyu2uz25ddlp849lfqeat5jy7cd"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1yg4qw00d3cpdvs9zyhyh32jkfcl8un8nxc3f08"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra19825apq06ve8ae5mhdtljcssm77xrtdkvm55gk",
+      "liquidity_token": "terra1lm3mk44nft4mn74hajn0p8x4enp6e38yyf4ey9"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1yfjk0jn42krryudpv04mg0c3ghuq4u3qtyztgq"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra19pkpq2hmmag2954jdwpd4wqrhqp64umrtw6tmc",
+      "liquidity_token": "terra1a6unyqwce532dq9z9uez3l5du2zqhqlek8cg2p"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1y273xzgr58qsdkc89xa6qu5y9padxtm265am00"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1rwezyr03fs72talr7g2gjgr9jmfew834u7gl5l",
+      "liquidity_token": "terra17v6ravmxwz8v9je9w9c23px3zhcvajk4tndt63"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1yv2fdec6ej4g8pv9sru5ezcz75a2zrczllxn86"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1mhtsdde76nulexf5p5fawnlnq2trs65zrd98zp",
+      "liquidity_token": "terra1jyy5a49r77le4l566m4wfun3pkpm0ed7n0luk8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ydznesu47hety3am8athucgp6hl4dcxsxqpka3"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1xxrx7rgpzlep532ulyyndpm7g2md3zspgepmfa",
+      "liquidity_token": "terra1m5gwp6ujj0frnwkgxlkmhwu5we9xaysnwa6f8s"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1y0spkg2up7ddqd98f9d45wacfwjmdvpq702y72"
+          }
+        }
+      ],
+      "contract_addr": "terra1935xkvhhrv8aeq7sl5hqez5uxlwvld3098mjmp",
+      "liquidity_token": "terra1l0yxvzzszzfcrfcle55wdf2xxmalc9eg5c28ej"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1yss9zexptelas8y4mqans2qscmw69cy2g0tycu"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1h279dtdp2jal5z46memvs3fqa9syfcnd92whp2",
+      "liquidity_token": "terra1dznxnr2k77nneklkd05jmxugp2j77mtt6v6yjn"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1y35nf8sk82pc2h8fh2cmud2ku6mwjc3r36p63q"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1xgm2h5fj259m7t4gtudshan3cxj9h2palphzn8",
+      "liquidity_token": "terra1y5aqgnkej7jceanvfnqyvp5l6qkzgls6pu9u7n"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1yj7vlx4uj39u8x4ptvvpxhpfnmphypmlhfhq42"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1dkhyzytlc99rf43n4jrxttwxcvg0hvmaa477cq",
+      "liquidity_token": "terra1mvht6zch65z2jstqfz6dye5wlazhhmc4eky6gz"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1yjlqptvn3al5402jp600l7n3l5yl8man8d4kex"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra1seh55ualnngk9jau3qsw7xrl4q7vqhc8y64w5q",
+      "liquidity_token": "terra1jnn5xpmeythug88hu66pwl3x9fz2s0ms034aw6"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1y5ffh484f3jcy62zuslx3qlv0n6c4zsffjapm8"
+          }
+        }
+      ],
+      "contract_addr": "terra1452cjwwujuejcyy2jujmw54aae96dsyg063ycl",
+      "liquidity_token": "terra1gzu6j09js98082arj8a0nxlz47enzp4m0sp588"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1y4yx8w0p9v247w5uv5hfqv2fccda7rmt65mwcd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1n5y7ym6x3ma0en8ff692406gtaagk8e7l4nyzq",
+      "liquidity_token": "terra1dntanjjlturgu2zn3t07evdf6cljepaap3vmfa"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ykq4e3ca2e5qgeetk8k8m3w6tk9tclr0xj2st7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1duyea9eyua7uftths0n0kn5uzrdsguj7mmv666",
+      "liquidity_token": "terra14janxct88y74znp68z4jh5j6hq3nfd6shr3sjl"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1yhlhrea3rgyx2xdnsswsfakn28qa8z7yp5gmhd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uchf"
+          }
+        }
+      ],
+      "contract_addr": "terra1tkxnksumzxnk327xt943g08lnzs3kmpa8rsn9j",
+      "liquidity_token": "terra1qlw5553lefpdkg86sxe75cea492l2j0jrga7e4"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1yeyr6taynkwdl85ppaggr3zr8txhf66cny2ang"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uchf"
+          }
+        }
+      ],
+      "contract_addr": "terra16wwzrfv28lhqzv7l9m9qnpzyae600dsratzqg7",
+      "liquidity_token": "terra1aws0wttvv6lzm8zmwqe2ppwkzexcc8wv4hph97"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1yeyr6taynkwdl85ppaggr3zr8txhf66cny2ang"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1rm73st5fn784udhcewduwwswr88ypk46cpkfma",
+      "liquidity_token": "terra14xyfs5wfsr35gpqnw9yy2w3ffjneh9gaace70c"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ye68rx8etwj7xylwc4nd4vp58zz236mlhk0cpx"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1t5prq6e8pygcyv7zwd4zs2nkxn7808fnqf5lz8",
+      "liquidity_token": "terra1y3k4vj8qhgultc388wwmx6m4mdlt2098fyj2h8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1y6mgy2ha0fwhtkd06jdca7hpep7z8hz9n2jz8t"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1cmvp86pqrt2r986v63mm5257ctplnf737rktl7",
+      "liquidity_token": "terra1wqa24s7qzqess0pwrx3q70lh0uj04vajx6uf58"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1yuvwz0wzd49mjlvh24g23jst89dllua0nc3knt"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1vmvsdr04xdhh7mure2v9lgwy7l6js6s3689qyg",
+      "liquidity_token": "terra1a05a50wz2n8mlr5nzwlsftzrdf9gvy5sypxdg9"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1yanmc0xxg9dl387qkudnysjkymgytj3cdhgeek"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1fgwk7tjfzcul8mc8xwdkf3ejswgcxkh7d087ku",
+      "liquidity_token": "terra1c7lwa0k2uu0xxgsqjlk4yaycxj3wwp4ft7lxsd"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1y77avpcwxc49ezmex8nsupklgc0qt7le44z4qd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1zv2q88u7pslnj00w6u7ketjq77tu6lupc2twav",
+      "liquidity_token": "terra143lm2z3y0atfzwqzgknse2t4wf7majdtrw4vps"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19qcznmhmwf88lm75nmrj3prr6cmvtnz02hvu4g"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1w0hm732ejcvyp59pru5e77j6wf92rdnkknf7u3",
+      "liquidity_token": "terra18nvqp4lhezyw30kwuufplp0urggd0z9uge6ucr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19qad83kr29qg89fpl4qh8m02wapmlwzpw5hvc4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1gy92pyp6kwllkpqv4gmw63l50cglzqmtz2jjnf",
+      "liquidity_token": "terra1s72ztquh9j0rj5w84kxlflkwz0kwyaflgxtstd"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19pz3ehx9f2thr9t9jk5y89aalxmhzuq9j8ak99"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1usq239ur4z4utc8s4ecdrk09hd062nrdcdc7yd",
+      "liquidity_token": "terra1sqd56ss9kw6fzx25y8krl8k703z4el9ttpknnr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19ztfg6l5k22cw8xg2h0uncpg3kwpv84ft9h6t0"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1w7cyg38vclgtlsw5vxgxxleky2x29p3lh36yru",
+      "liquidity_token": "terra17selfzmc4a3dlgn5ewtwkg99a4hkhgtshh4z7f"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19z03z40dtwa6j5680xt58md94c3fsyvsnmg82e"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra15ktt9jqw8hpzg6w8erlwx3mq5qxjnnnj46we5j",
+      "liquidity_token": "terra19y6ydp9p8qqs528xygm3380w8cwflqkczv2s59"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13rprqshf7dxn48v0aaztv5c7ytct6t6u7djtlw"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra19z6n7l67rkg6y7vggwr3jh889t9vg6yn2jdl9n"
+          }
+        }
+      ],
+      "contract_addr": "terra1l2shns0h89570l7fcerw6xs6vqgkmxmdglt6qw",
+      "liquidity_token": "terra1f8r2zlguqp9842tasj8v0d7t4wp0s3mm4a3dxw"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19y395vzlylv3s3nasr7cu4yey7s22ghqd35ps8"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1wgyq7kdeqeq70uzv04effzrgndtmtmevv4p9xr",
+      "liquidity_token": "terra1vw5m4wklc5fg66hhlg3sulk9sjwz30dnudf259"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
+          }
+        }
+      ],
+      "contract_addr": "terra1naeq3qjrd0mzw2amr0yr42mmkpmq5nrsxvnyqp",
+      "liquidity_token": "terra1hv0xq2uyav58w57dckcvcg3fu39gvrjca737sg"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
+          }
+        }
+      ],
+      "contract_addr": "terra17rvtq0mjagh37kcmm4lmpz95ukxwhcrrltgnvc",
+      "liquidity_token": "terra1p60datmmf25wgssguv65ltds3z6ea3me74nm2e"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
+          }
+        }
+      ],
+      "contract_addr": "terra1squzmwcpr5486f0zp759d5zyt0q3yykaf6e4zx",
+      "liquidity_token": "terra1ect4kjuvn3sxh7fwmsj2fsmy802j4c2pnt8j7a"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1l5lrxtwd98ylfy09fn866au6dp76gu8ywnudls"
+          }
+        }
+      ],
+      "contract_addr": "terra103ttjgs24wak64epwd7pl5qmqw44jzujr8l3hd",
+      "liquidity_token": "terra1wvnwpt66528vajjps7m9daux600sck8mhx5wmr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1999psgmwex5f7fs0u9nnxrnu82c0c6s7qczhxy"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1hnpr3uukuryj72al4knes8a2eerpfjpf7phmd5",
+      "liquidity_token": "terra1gs3hkq6qylxukkklscswd98ar9lxqguzu8aed2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19953ttzk3mxghgwpdt85gua3gzzcj9a6wjwek6"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1pc7pufyc4z5lcwm0fhrsveu3fxly97htyh2hnu",
+      "liquidity_token": "terra1ea6srqjggq3j8spanguqfekcklwnqwren6km9t"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19xk3rsesaupv72se69y8v6y6m04fl8yj6vnmtv"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1nszsz38jnmfs6xl9tsq093sc23stm7xz33dqqx",
+      "liquidity_token": "terra1k4gswh2lyasmggzedw8y23v6gpxvgp0kva03xg"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19fd35n93667mg020fj5lupws9rhkw59cw459wm"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra134jare8j7annsu6fgtkpu6zp8gmfau88jrsnaz",
+      "liquidity_token": "terra1yp25tl2335p6usfwtfl0qt3z7utglx9zrac4z9"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra192g6ran4vfvyxhz0q7g4yls29fk6379hza6plw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1vfwf4vd0yp47renczuqe8n7yrraxa2j7a7q0jf",
+      "liquidity_token": "terra1cps2jsd3flznjzce86qyma34a4d45v0wz0yy4j"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra192dse96aslp5cduzvjqly4j7jaka6dlv2xx7f8"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra17ds00wg6xtgy9f7apfl59f4978svh626f00238",
+      "liquidity_token": "terra1knn3f89x8tnf6h9aglz5rhz96wa2cgwfsx3mwy"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19245ct3nfz95j3peem0zxy0e8e0w2uq4n4ssr3"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra12uem5pwjtllme9dnw8ccw39ewvgyetrhnlnhtx",
+      "liquidity_token": "terra1vv7cqzr6ppgkueq4qgykfjfjsdlufvpljcxf8x"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19tvczk4us839rsvet9ncwg8est73nmzecdewkm"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1qrrr4kqfqptd7wx0f45sgem6z8ejenh3k7esnx",
+      "liquidity_token": "terra12j3ye47a9jjk9jtjg7k8f0rs09hsvdpp6tpl58"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19th22mng47zxe9ndrtvd470fjkn7n7ymmn28mr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra129a0pp22q8m2m9lvd7n93pzx5eyjw2tj0ueunn",
+      "liquidity_token": "terra1w22ns4l6sz3t39tx2z4lvxlnu8ejus20k0f2ts"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19v4cg3w698qprsjwzw52cns6245vkxug74q9lc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1c4r7vdd7f3cjts6kzjuv0sx4apesxr9p55kqc6",
+      "liquidity_token": "terra1hndks78y9k49jq35x4kwjsvpp8g9hn26e5n7d3"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "luna"
+          }
+        }
+      ],
+      "contract_addr": "terra1ak3u2e0303wvnfsese2z382pn4sxl9etz9rrkj",
+      "liquidity_token": "terra1uc9r5fcjzrnl65agh3eajkmle494msx7nynsv6"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra108hz9wugglvu2rjty2xaddvwtr09ukd7kwm78n",
+      "liquidity_token": "terra1nzlw9mny82p598ue0d4skguwlffhl5vdszjr86"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1z4pwt3nqrwkvw26vl5tr0pm595t5qf7a2s20kk",
+      "liquidity_token": "terra1y7rnxw089cv0a5t5jlaa6wuh5uaa78rnm5k7n6"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1etdkg9p0fkl8zal6ecp98kypd32q8k3ryced9d",
+      "liquidity_token": "terra1c9wr85y8p8989tr58flz5gjkqp8q2r6murwpm9"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
+          }
+        }
+      ],
+      "contract_addr": "terra16eecm8exp3p82ld5eh5feweup0qvfv8468np6j",
+      "liquidity_token": "terra1yrthzcrf6p0l568rk2uumzfg0355zedywmaf8z"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra190tqwgqx7s8qrknz6kckct7v607cu068gfujpk"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1t9ul45l7m6jw6sxgvnp8e5hj8xzkjsg82g84ap"
+          }
+        }
+      ],
+      "contract_addr": "terra1swdaspvv9w0wtf9sylmkdmfnzjx7eu5734n64q",
+      "liquidity_token": "terra1c9jc8r4ddulrgl5d9elt7np0gavlcjxwy2228s"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra190tqwgqx7s8qrknz6kckct7v607cu068gfujpk"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1u9jgz9t8huvxcfc3u4w78u3fdxftcmzv297nc2",
+      "liquidity_token": "terra19zkcq8cq3w8vl58w7nkz07n6y9ujc47ftcakgh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra190tqwgqx7s8qrknz6kckct7v607cu068gfujpk"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1c00vskhyzdv0z63z2tyetzx2qma67n2z3vzyn0"
+          }
+        }
+      ],
+      "contract_addr": "terra1p5a83hq638z7l5eqr0ll8tnayy3gecakzftc8m",
+      "liquidity_token": "terra126evm399rxsvzw06qe9kxcmv3ly5lwarycq5nw"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19slzdkvt3kekyq4ydp3ky4pjuus5lmedafkkzs"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1e5qq4ee6wqg82jylt9n3ta8ksuzm4f5qz4yr3j",
+      "liquidity_token": "terra1nmgrvljhtkyd6h20zefukvj22lf03yvlj2gdlv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra193c42lfwmlkasvcw22l9qqzc5q2dx208tkd7wl"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1mveechnw84gnylqjs7v5wrk9ky9jyly6lsfmfr",
+      "liquidity_token": "terra1j0mx27zxqne7e7c4558eksje8n8368v89mjc7k"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra193c42lfwmlkasvcw22l9qqzc5q2dx208tkd7wl"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ykfz4hrq8en2f098j8a4ppaq8u8hangpw9tnqu",
+      "liquidity_token": "terra1vwx88jskew3sdf2wpzj6e03mtw2t0c0rajg72u"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19j57fzwjahvf52wxffgrajd0jjm9m8akfsl0qw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra163ddeunmzqr90qw4j2nxxmk0fmz56mhly4g07e",
+      "liquidity_token": "terra1cw640zur4svu6942kq9eu6ruxupryjmz5sd9yh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1948uvsah8aw40dhsa9mhl3htq8lraj0smlh77g"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uchf"
+          }
+        }
+      ],
+      "contract_addr": "terra1qhnylhd7vdu87sdyjs908ndxc4ck0pgzpr7ky0",
+      "liquidity_token": "terra1knt7mzm6ndw35tc3upfgxwzdzpn398ftmdsxhk"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1948uvsah8aw40dhsa9mhl3htq8lraj0smlh77g"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra12kag8guzdfyz5zsazup8td9qw5pawl7y5hk0at",
+      "liquidity_token": "terra1uvcehlp8e55zh2567kwr5kl3pk9mny9dnr3uy5"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra194a6jn3cyydhrfpdnz5r5zkj6wx3t3cr673z4r"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1r6pp7pp0pgvp06nh80qmu697qfjsegddqnsg8t",
+      "liquidity_token": "terra1ceg8925w6y833wsn5lv7srpf64uw9rf3fsgwxf"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19k974ngjsml8dtmk56cdhuy6pplr94rxqdt95p"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ust"
+          }
+        }
+      ],
+      "contract_addr": "terra1kag0uhcl2e7tddmzaavqr7agkhr9ukghutryjm",
+      "liquidity_token": "terra134cyuqglj8nmz2us3y7nl7z4mqsmj2dx8f3xq6"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19k974ngjsml8dtmk56cdhuy6pplr94rxqdt95p"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra13tngwuhz27g97gue2wg36nsc73agv9axnjrmd2",
+      "liquidity_token": "terra12zfj4sczu849y7q3kzdlxxd9x7y3wjx5xtjmau"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra19hnegq0ed5w0gds64765uakh5huw7jepvjakh5"
+          }
+        }
+      ],
+      "contract_addr": "terra1a8t3w4ts39fu5su3dg60p9akhr8uf85fzccuxq",
+      "liquidity_token": "terra1w507ax3yxh7cme3fdk9wamurgnakt4ej7syq7s"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19cxwwhtkpp4qvf4tvjmhh8lnh8lle7uw7ndqjw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1atzg5zp4p9sy7k9urun8q703upffm2maffm8tz",
+      "liquidity_token": "terra1seymtr0r73sahrl2y8ul7afjp87ldrct8vtksh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19cnnyaah7c32hhcdt5m83pvdxa7ts64caarcm8"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1zhffgf949uvq8sxgynmxa3n477sgvd4gf64w49",
+      "liquidity_token": "terra1jlme2556ygty3va4sw2k2p8j7lz5felpclvq0q"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra19cmt6vzvhnnnfsmccaaxzy2uaj06zjktu6yzjx"
+          }
+        }
+      ],
+      "contract_addr": "terra1krny2jc0tpkzeqfmswm7ss8smtddxqm3mxxsjm",
+      "liquidity_token": "terra1ekd58y58vq4gmxlzpc27dwuhw7wmms928ftuep"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19m0xqgdaltwkesdt6m383jkqh3m9xyxwtp0f6f"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra16yrzqhe84x86jzgaav5hszfsu4mhxjk0aqlk2g",
+      "liquidity_token": "terra1shgduktaen6fx7zp637d4ndp99j59jttdp5wnw"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19mcqz609t5vcudfatwexuhta0mrs49fu9dqj2s"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra187pxc9su35stqfdd02xy2r778qd83lruaey3fq",
+      "liquidity_token": "terra1lcrpz5rgtqu6dejec7nrglh6qqgt8326ecwral"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19ur0s3h72v7t2qmy58z60e0cl0epkal3mle4mu"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra166lp9jpsca40cqhh78f9ve8t4nx446yxp6ra2s",
+      "liquidity_token": "terra1zqnywcumfdnueyccgzp9qjzcaf7zuzc8hu2fts"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra19u8cgzsmgg27mnevcc22293yl3j82f26l8nvtz"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1nytaqyhspr05thllfkl9lgnvmfwxdxmcy42k3s",
+      "liquidity_token": "terra14fy4yzl893m0wqh89mv6c00lnutmgrml08ndrm"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra197txx8gsllv9rakjs6zh7pw6hnlgvte8yf8a8t"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1lz2uwr6jqjp08yqf6fee8n484hdxa2rzpte2h4",
+      "liquidity_token": "terra1je8e4j30696s3j2tv4rvscnzgsan87uqy694x3"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1xp4uhylkhwgam5tc97m0xfaxarajgf6wtcqwp9"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1z9d33epxt9jaa4d4ta6rf5fwfysfufeumz4zga",
+      "liquidity_token": "terra1vemqvqr0khzdtfl9909u27v977pthardrwf9zh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1xpueuqns7n6rxfuagcpphm77dfyn05fe0cjfm0"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
+          }
+        }
+      ],
+      "contract_addr": "terra15gg2t0px432zf2fcvnu5uezmj7kcrt4fn2wnpq",
+      "liquidity_token": "terra1zttwu40dcu93l4kcr7pcyrhzqcxvkvhw47wdwk"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1xzn8e3h9k4qk7082z330sn8ptz99lnghyua9xy"
+          }
+        }
+      ],
+      "contract_addr": "terra13hprd7adym4cf2hgjmnjdv48akxj8fplelp6pz",
+      "liquidity_token": "terra1ky8la6rcvuj7ks02lj0vqsg808jj8rq6sy5lux"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1xzk97nrq0ma7dzgy6aj5tm04sg92q720lq2yum"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra18f5npedpgufd4zyq8gae05c3htnkex7sld2rkf",
+      "liquidity_token": "terra148se8h985hfw3s3jl86vf95qgfz7hztdj0u7qp"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1xy2gf523j92khfn8nx0uurkmkguul2u95cwv8v"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1yecrrjs5alr5vakfrvvh0yrufvfla50fpcvefk",
+      "liquidity_token": "terra1rfrwm60zydsdsr9hy4smp7sckuq57nt56s3tp9"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15pv3xxp2d5f65qeu2v27vqf9zpqjx0fuztfwcu"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "100000000000"
+          }
+        }
+      ],
+      "contract_addr": "terra17rt5kvtt7vgdnxyelqhctaa4p0wwszjqx4etr3",
+      "liquidity_token": "terra1q2xj2w477fd8vx4n4psa449hj03m8py8la423q"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1u4gx4v0nqgzm2kcajk3xf0d35gutwcvdyyjrnc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "100000000000"
+          }
+        }
+      ],
+      "contract_addr": "terra1pkuqexqszqcxszy9fpmxdnl6gwefjd7vger0jh",
+      "liquidity_token": "terra1w4276v5yzxa94ess4ryyfwanssfr3psgyk4jm3"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1x95tutcwe4tjxcdvtgrjg5jxkf24sm74xz3leq"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1enlwzps4sr4g84jwr3qnx3czcvf5ayjgfyfxuw",
+      "liquidity_token": "terra10dlmpyedw742sjg99kkh3sfyy4e0tqkjfd3qyh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1xxze8dty562la0d6g9q3srlddh0qemk08kpgfr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1k40xfmkswya285zwcsj0qlamg0f4kyrvn2cd0d",
+      "liquidity_token": "terra1ryc8v8srh8kwclxcay7dgqtkclty3g5n7gj0y5"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1xfsdgcemqwxp4hhnyk4rle6wr22sseq7j07dnn"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra188w26t95tf4dz77raftme8p75rggatxjxfeknw"
+          }
+        }
+      ],
+      "contract_addr": "terra1g8kjs70d5r68j9507s3gwymzc30yaur5j2ccfr",
+      "liquidity_token": "terra1qf5xuhns225e6xr3mnjv3z8qwlpzyzf2c8we82"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1xfsdgcemqwxp4hhnyk4rle6wr22sseq7j07dnn"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1hr3dnvgw5lp36gj5chc9k8te525sa6yr44zeps",
+      "liquidity_token": "terra146ndl4j5mrps92ksc39wm6uc9j2w2hq9ha928f"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1xfsdgcemqwxp4hhnyk4rle6wr22sseq7j07dnn"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1zkyrfyq7x9v5vqnnrznn3kvj35az4f6jxftrl2",
+      "liquidity_token": "terra1cmqv3sjew8kcm3j907x2026e4n0ejl2jackxlx"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1xt9fgu7965kgvunnjts9zkprd8986kcc444q86"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1n6snwmgzpfs73juuxurwxmt2md49s2l5ggf5f2",
+      "liquidity_token": "terra1u9ytts0kz3lsfg2z9804u8pdyz79283n5jevum"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1xs3pv5rd2xu36w9vg05shkgxcrxkvz40fhnfsv"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ukrw"
+          }
+        }
+      ],
+      "contract_addr": "terra1nsdxqpe5upkvy9jegqdkzyhetravf8vl7m496h",
+      "liquidity_token": "terra1e7d7325sjpfk02vnzqkwsnlu0xqejydleeh2h8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1xs3pv5rd2xu36w9vg05shkgxcrxkvz40fhnfsv"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra1n7kaxpxslz5aw36gx2mnc9a30n4yu0us7x2xj7",
+      "liquidity_token": "terra1237hndgalhuukzuccfvfjj538az8739td5cnaw"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1xs3pv5rd2xu36w9vg05shkgxcrxkvz40fhnfsv"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "umcp"
+          }
+        }
+      ],
+      "contract_addr": "terra1h205tvn624npz49snyha3l4cv60d9kccvdr3cn",
+      "liquidity_token": "terra1klc5n2zy79ttxur0mdvhqldyzhkmcehaqm877w"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1xjxegty6mmdr5jwqwde9rqhz758sy8c73vxzea"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1rds4mfy90pxtn64px8dq9d68d2vwkcplpt6sl5",
+      "liquidity_token": "terra19uca4zxqr8e9t9l6lcz3rztzaygnawwlex8g8l"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
+          }
+        }
+      ],
+      "contract_addr": "terra16k6jl4sywwp8sasgdgq54qxyk35uhqnnhm4d7f",
+      "liquidity_token": "terra16jjw6yz3ng02dwm6j46hdyzqfula9sdyt9ym0p"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1f68wt2ch3cx2g62dxtc8v68mkdh5wchdgdjwz7"
+          }
+        }
+      ],
+      "contract_addr": "terra12fg9w4tcvn55whjsxhdjlg73echp03vv382hdf",
+      "liquidity_token": "terra1jhn27hndqksaehh00ce58nrzfv2hxfaym7zmca"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ueur"
+          }
+        }
+      ],
+      "contract_addr": "terra12tuqcyr3aw6fuky8l2xfp0uyje5kmdf7yr6spa",
+      "liquidity_token": "terra1yyngu9q2jc9det2lp3ffkam4cwm6jqj6ljcv0p"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1m68xcezywdvdwr7tfe9lauygx99h7wyx64ss7m",
+      "liquidity_token": "terra15kezlnepzjk40sx4d0e3q46shkwwv4j63hwt7x"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1pufczag48fwqhsmekfullmyu02f93flvfc9a25",
+      "liquidity_token": "terra1xwyhu8geetx2mv8429a3z5dyzr0ajqnmmn4rtr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra14lpnyzc9z4g3ugr4lhm8s4nle0tq8vcltkhzh7"
+          }
+        }
+      ],
+      "contract_addr": "terra14q2h9nce4spj8n74g6kppj3yf86qx8hsrqngfh",
+      "liquidity_token": "terra1h5egnh0uu4qcjx359fgr5jfytjsazsynhm7lw7"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1x5t6zkvhc6dg2jjug34tfreme3hcufpuy77da2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ukrw"
+          }
+        }
+      ],
+      "contract_addr": "terra1ps8wcwxt783qq07gfza0f67xf3kuaguq0r0e4y",
+      "liquidity_token": "terra15qmh9jl388v2hr2yn75v8psdj0q9ghfwwxzckg"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1x5mhyxzmy8da89rh7dnt3v289qz988hclyl6kk"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1yqrryqqnvq9wgqad89dhdxwspspqzzj2dy03yy",
+      "liquidity_token": "terra1l7hmc3k3zlg5r6jet9tuv846h735p3xjul2dh8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1xktc8znx48tuypg3p47fcgfxrhc07hex0qgpex"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1dv8tp8nustr58z0mlg8v4jpxjd62s2g2dflwhr",
+      "liquidity_token": "terra1yxlq4zezzvkha2e8wmck0nzx9e26xrjylk2dax"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1xk0a738cxushekjtvf6f9qtr7uz36yxc3egne4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1x9jv7vjcpy46k7eadp9ldx0jkkx3f8n2yvwtxe",
+      "liquidity_token": "terra1tctqptkl50uxqt3wgpt02cmk8vxye3a3fvcm7f"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1xhqxa9c3z223lt67lt86r2lsvtmuguddc9g55m"
+          }
+        }
+      ],
+      "contract_addr": "terra1mvjm8g5zmwutqmqsjaq6q4rtv96c825v3lpep3",
+      "liquidity_token": "terra13dvh4d653c6tyu7f30hwcpjnrz8xhx87yduphr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1xc5ll57yu269x8ysxvdpjmvxmac3js7pst5ddr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra105lwyhfuw0p0q39tghg2hxnjdarg6uy6n9s24n",
+      "liquidity_token": "terra1g0qrmushesf6l7cwmvfm4nqh8dakrk3a7daq0j"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1xmd43yrfxm4xy3lnptc7kr4rr93pzh5u0z0wgt"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1dj35t0w5w5knw7cq6dj3s68ry724nctq069w5s",
+      "liquidity_token": "terra1ksymk0cy2lvhqljsa97c0t7098843289k6pneu"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18zqpuua4d8u9q9d6zsn8fqtjj5k8hk845prz9v"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra132hq2uqczg2d7l4czhtcdwwlgl6cga6rs3nv6p",
+      "liquidity_token": "terra1cu22t7m64dpm0fsznnq0t74etu3p0q2xh974vu"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18zqcnl83z98tf6lly37gghm7238k7lh79u4z9a"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ibc/18ABA66B791918D51D33415DA173632735D830E2E77E63C91C11D3008CFD5262"
+          }
+        }
+      ],
+      "contract_addr": "terra1eyf6vaampd2tqzxnd4eajkre2574zl252e8ncx",
+      "liquidity_token": "terra1uvkn3jnywxeqqtucnvk8wzzghhkqsdpz55rzh5"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18zqcnl83z98tf6lly37gghm7238k7lh79u4z9a"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ibc/18aba66b791918d51d33415da173632735d830e2e77e63c91c11d3008cfd5262"
+          }
+        }
+      ],
+      "contract_addr": "terra1jatgfpvukan93px6kqkfdg0k8lwjh8rlw9rume",
+      "liquidity_token": "terra1s346ahst97qm6lm6rw5hjy68cr05ymqf4u8jg2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18zqcnl83z98tf6lly37gghm7238k7lh79u4z9a"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uchf"
+          }
+        }
+      ],
+      "contract_addr": "terra1mqcremxfr90hu5a7nvyrn7zkx3zu26ndl4zeua",
+      "liquidity_token": "terra1dugqpn2r79rqlyudz7xtfd0nqlt53ek628a0vk"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18zqcnl83z98tf6lly37gghm7238k7lh79u4z9a"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1dy4dpuxev7y4tqa0rhwjrc6e4yz3w9gqr6szz3",
+      "liquidity_token": "terra1g7ze40w256lkrma0km7p5v0yk200mvw97ygw6h"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18zqcnl83z98tf6lly37gghm7238k7lh79u4z9a"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
+          }
+        }
+      ],
+      "contract_addr": "terra1j20n7e6klfkp2xjruh000u5lhpj2fgfng3an84",
+      "liquidity_token": "terra14ex4azzmx6dez32tf5xm2432ua577krfz37c8v"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18zqcnl83z98tf6lly37gghm7238k7lh79u4z9a"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1cdg2m5swqzatvzuvseef9xcxpwqylx2h983hm4"
+          }
+        }
+      ],
+      "contract_addr": "terra1y8uendv07j259m26dmw0mtcy4mvc5wc2qhptyr",
+      "liquidity_token": "terra1kmf20rwahh3e22af9u6vq2h5s7kh89fhd9g5ds"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18zg84fg56lthpjd8skj70l4zd3puyul5weqfer"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra19pldqzpsglzusuj59tw750yp5um885c4u888cp",
+      "liquidity_token": "terra1jed2nwcyz0xx8qutczeze08axeetcagawf32lc"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra18yqdfzfhnguerz9du5mnvxsh5kxlknqhcxzjfr"
+          }
+        }
+      ],
+      "contract_addr": "terra1lr6rglgd50xxzqe6l5axaqp9d5ae3xf69z3qna",
+      "liquidity_token": "terra1s0dgcsdy9kgunnf3gnwl40uwy9rxtmc39mhy2m"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18y93cy77qrxx65vdz959g2ngms55v3s3yythys"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1qyag7j7s5z0d02em5g09ltgcztxpdguz3pkxjk",
+      "liquidity_token": "terra1fg8z4tvpm2qdq7wqvpdyj8ez9wvs2ntfr8mqag"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18ys4xv4yjy6c7984mv4sz08p3rpl8cdtxxhuhw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra10dua387cxqwuulwwpcvk6atwe5alkh6qky7xhu",
+      "liquidity_token": "terra1kdqt7wfvem3nmdsrr5pwqlnhzl6w8xklqey35v"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18ykszsm06k0suqjvz0q040lm36u7pn9eeq4uc4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1uxduyw72vlrh8t0hvmrwn270l7z650ykeevx03",
+      "liquidity_token": "terra1qajzf4lefy6wcvpc0dk7fvundp8arcukz7jwp4"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1897wmaycufjr9hu894mt0g33ddcgm9vfsfcyyd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1fyrvx3m5njh265wu3xycty3ynf04x8wqhpm2lh",
+      "liquidity_token": "terra1hqpfh2g457fuzrm8e0skagwwh79pffr3zzqwek"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra18xyl0ees6ueyhkhn0mjdtrm82e393ult2dazl3"
+          }
+        }
+      ],
+      "contract_addr": "terra1vwk0dhr5lha56ssddl58ntxlcunfru36d0jfuf",
+      "liquidity_token": "terra1vzqxu4d5rm68mgtjcfhe6xpydy0axwjhleny2x"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra188w26t95tf4dz77raftme8p75rggatxjxfeknw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1g9rrgs63wm55ad7rv6rmj8hu8nauc0ru4yussv",
+      "liquidity_token": "terra1a24wnwx8c3yg0jwu8hsp0qwrvuv0pz7ed09gwj"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18gtpe3cu99pp2ej4mmf5hanrfwy6qcvd5x5cmz"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1k7ugqrw3jkk5auuudpnuf52wtzerx4a7cjjhfg",
+      "liquidity_token": "terra1ch9gwujlyz6pjptuqcdpyawn5a87dtw7a360v2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18glhvftntrqg00hv96qkpx3r37g34qh8qytnps"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1eu62yulj5zjhs8wa9uvlj5l92a809a2hcp83uv",
+      "liquidity_token": "terra1zaqqruu0ch0qgq2s2djkelywfn9x9yfg7wjet7"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18f86dw6n40r6hqzjw0qsfe09nxesqs7vx2jkcx"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1qsf2sn65fjyc5hvm2v9a65qcyc23fnylr84fsg",
+      "liquidity_token": "terra1cazwgay0h75rt78q2vxr6eggfk25xf4d0fwj7c"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra182vnsj0rv9dnrc7xnccz0wajp69hu73706h2p4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra12frjaujnaddrfxjdlet09nlf75waxclze5s0rm",
+      "liquidity_token": "terra1s54fm8ttuwavqsc7m9salge348upw5p53jnj8a"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra182740uw8nh6tk3yjfcf7gu5phg3kqryhtuxp0p"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1zrx57z4qhsejk3r0ug6pt3xvz2efpee39rle5n",
+      "liquidity_token": "terra13gq946x6dddjzfa2dwpr2pq6uknqnafspzkzr0"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18tc5vrxzvxwlcchq83d4nxy635cu87v8g0030y"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1n0v5y6t5qakqsl504q6x5f2qvstqujaavxcapd",
+      "liquidity_token": "terra1vcecxknz3rc8ktpc9pgrxg578fsxlkksnuwx72"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18vl2cypy8pdys2qdqlg7pzmcmpqmur8lmrnk2c"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra16g8fsnjsmys6dl25s7wvl4r7y68drvfjc7pszl",
+      "liquidity_token": "terra1n347g69jtaez50mva3unn9npyd0jfkkzge9p2t"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18we4g8y6u55x7atttzu5xgx46zzss0tpmktf9s"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra17y80pnvqu3kd3g5jwn5kpkfp6hh2stzxmvazjw",
+      "liquidity_token": "terra1h8qvlt5tvwwpykkfly4gatmxdkfddx0te8p265"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra18wayjpyq28gd970qzgjfmsjj7dmgdk039duhph"
+          }
+        }
+      ],
+      "contract_addr": "terra1h7t2yq00rxs8a78nyrnhlvp0ewu8vnfnx5efsl",
+      "liquidity_token": "terra1ktckr8v7judrr6wkwv476pwsv8mht0zqzw2t0h"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18s2vq0cggrtvxvcze9vp8x7cd66p35868nz98w"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1pv75j3tg7ds4ze5vnwgsqlzltnn88gwu8hh9jc",
+      "liquidity_token": "terra1cgpwsh6cjfh4nhchy2k7umx98zmwqhh2z9lgs3"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra183x8jduwtdgcqkwtqxdzjlq2mq0rlnj6hm22j7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1sa70wy0857fzu2gjcrg4mm7n5767k7lhj3yrct",
+      "liquidity_token": "terra1juspa927c7kdr0jf7wc0lxg6wfjz2cersm9r82"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18jv5j86hjhc0zx280wu3kjggd9dvfyl9v4t04k"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra19hmp39k3dlwtywtqcs4nrr4lal66kzwc7ea42r",
+      "liquidity_token": "terra17jrxg9srhvhu2rcf5umt2lnrvahtgxwate8gej"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18n2k7nwwkgn20epntr4usy8nrs4l9ecu6wzqv6"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1j0927vf9tuawu3k85q73jjrp58mn26psmmyw75",
+      "liquidity_token": "terra143h0kw3eyt8xjfl8pg77xpjd4alpkns4su3gls"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18neulu99zm7kj040tndhavjskjm7aaxsk240rx"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra18g4d309jykk54l43k58fjqq8h2qdpzgdctxfwf",
+      "liquidity_token": "terra1mzpxqr5vwnzl822sjd3yskaekz2lyvfpavush6"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra185fgz0v2wm79ujn58tm3qeucnvlnfuffa4wpjp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra17j0yumlretpyprsxh3qk5zwyzfrdydgnpt0zh7",
+      "liquidity_token": "terra1c063gh7d06rdwem37tqvmqhfvwce7m2aypyrhf"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18ky9ln4g6x3n9f9s8a5ttshynv6lgzfppmrmyg"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra19rsnccnawx00kzynaxexxh4540qp5y6atfrkjj",
+      "liquidity_token": "terra19pztt2p6wuy63dehanjeuyf7vx399ptwdq93zj"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18cs7aktav46v3pwxr8r2hfkl9pdfmrthcn58qf"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1hukf5q2k0pphwlmc752aay5qtq29mmd5nn2s7a",
+      "liquidity_token": "terra1kksfhstvdl9ht4pxzx900279s7fdaqp3un6l40"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18ejpjp9eyx9t8j07jd7kzah9p0rvkzdfeeva6n"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1t82m784qavjuawu2n6m47u6gch9wvfne38pftf",
+      "liquidity_token": "terra1dmqluc4f2gk8yyss95sx8zmqemqndpw20yt8g2"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra18ej5nsuu867fkx4tuy2aglpvqjrkcrjjslap3z"
+          }
+        }
+      ],
+      "contract_addr": "terra18cxcwv0theanknfztzww8ft9pzfgkmf2xrqy23",
+      "liquidity_token": "terra1m8mr9u3su46ezxwf7z7xnvm0jsapl2jd8vgefh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra186qt4d07ghj7dm2x64tyc0muw6rl2876jlhv38"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1qhpgt8pglujysknesj6jnea5tjc47upuutmee8",
+      "liquidity_token": "terra1gzvdqgg9zrgv92948l923hjnvxgldwaqzshla3"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1866wzpwzmrnmh0s267twyhr8c4tc47tqj5aths"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1g6jmfxv2rangz50u335rfum2fxxqmk4cnl43kw",
+      "liquidity_token": "terra109kmkve0p4ksffjdfkry75d44hy038mk7x6ygc"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18m523525ntva277qramnc6x2hh56a28w0vndjf"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra182n2psy6gl9u90gltznv2r0h6t5sz7ajgu4dl2",
+      "liquidity_token": "terra1xp7l5hahtcl23ghx5u6sw5fa7cds4anmarj5nn"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18m6fr3fk9xh0u9vrvyeu25w0k40dptfrhw53rh"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1p445mk3wsctep477kpzvp6a4xekyzu4fqcc456",
+      "liquidity_token": "terra1zeestkmhgk2vjwq9wg396qpjvryftwqt2u0xt8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18u4zkkm5ddge6decp83dk9zmkx7lvhv2xkynrr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1wxl8ay7srh0cuwmtaew5yh7dap54f6vrayhnwj",
+      "liquidity_token": "terra1tyltj0lhs59mekgw8ej2dt49adue7mwa56xa2m"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra187zprsu04wnfs64pznf69mkls6vefhtmtwt8w6"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1cuxd5x9vs0m604pze90c0xgccraucv2kqcwlz2",
+      "liquidity_token": "terra1pgjfhamw0dv2t9a5d9q9eu7fm9etj4zcewyak0"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra187lnjdwluvfnzxcef4appgr4v7fwljj5d5wdhf"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1rg9p352hcepvclfrxptpk0ua7a0tz4gcc0f0p8",
+      "liquidity_token": "terra1d2muut0rea9fkff6y304yn6qkr2uacau7ltggc"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18lxu0868tj9pek9xn3wlgnlv0hs3s9t6473saz"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1v8mkxsvtjjdln52ltu6u6ak87uvmvgffwvt0vx",
+      "liquidity_token": "terra1fhzyy5jgrjl2adhk3swalzdl4hnh0rmnusk9hz"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18lx7nzwlp8sr83y2wymhj37fnrlehm7rj6lhlf"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1q5uy25egxd95tt6j7kxu26xtnn50pl7w6grq0z",
+      "liquidity_token": "terra13wgcwjzgcphqgcay6k06th604rdggjf2plcyjz"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra18lk5y974rsknqmcqlruj636mvg57yln93ay0h8"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra172nqk47g4vc3zfde06nkq0em69lcwf6dp9uj92",
+      "liquidity_token": "terra14e8sutnxhzgfzt4gdq84dqjymz422k75nglnp7"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1gq2yya7grd359c4y0wjfdusgrh805r6ml9jyyl"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1nvpfq78mfe6emt35f9fgys2vxwcdt3kx28g08a",
+      "liquidity_token": "terra1r2ec9hu0l8d2xrl6nnawy7exmjyrlu4usyr5fh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1gqmd09k8g3lggxxdzu9z94vqcxtr5zylvs95ke"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1hakq6c49989jkgpj4qcp4akxqgesazps2ss9lp",
+      "liquidity_token": "terra19c5fhtrdaarv2cly5su7w9a2ud7nk72g2vm0gv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1gpwkclxwwuzd5wyjw2qn3km0r5ge4t4f4mnf0x"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1jwl5rzg3xe0a3f8r26l0l3d957vlxm833srtcp",
+      "liquidity_token": "terra1srcv0x7huzrxce3awyl4u5g9rpt4fqn5nwcw6m"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1gxztmp6dlu8xv8kdlty6259gl845mw53gakw9t"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra188xye9e9w0yg39qtxq8tnzfmprjz6h646zgz72",
+      "liquidity_token": "terra1hdthg6xxx5svjh079x0frrzwl5wyytw2l5qm65"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1g2dz304juraseqdqq6ufnktqgeqen67sct3p7d"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1l7urxwu5txjsy56xcuaxac4et42ll3jnjnjrsk",
+      "liquidity_token": "terra14cukkjnldflzke4x5xq5fgf3txkfq99zw5l35q"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1gtjr689cyaau20k8ezdxy8eup34tntun5xr9l2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1d3jylrg6w94akvu0dky0y6l62sktrfzd4zfkq8",
+      "liquidity_token": "terra1w3ffc33tpmwc3fa0ga8jlqne647k3jtjftrsfl"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1gtjtyyhj2cu0ekzju4rj86vsvg7d2uu576rrl7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1jpf8pnqqswwwnpygsk4eudsujr9fjkh9f4gjcv",
+      "liquidity_token": "terra12pltplchslx9wmsc2mey5hvramycnmnra974f2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1gdze0yyar2y6vs3un79my828cery0jea8mzn07"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra17fwqk93kurqedvdyrly3a0c9g2v8eax3j7l5ek",
+      "liquidity_token": "terra1k6mgu6smngvqhq63stjgj2vq9e49umxvr0e6cn"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1gdapfuda0dxtjc98raemhszntcxty7chyr0wpd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1jgzc2rkgl0nlxxqgy097wtq55c7qv224ysx2dw",
+      "liquidity_token": "terra1mqhv4thnf8mpwvj6ul7wrrjs2y5vua257yhxns"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1gwr8mq2ljqzwmufgm55yu58339k55wja9529sg"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1u8dt2feqxchklzft7n0s38d7kz2wwx7zqey8z4",
+      "liquidity_token": "terra1quraxjgn87qe63h53mu8ksulqywsdlas648axv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1g0pm8xm5c2dq4qtv8j9a80hg4mhe5ndy8qad07"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uchf"
+          }
+        }
+      ],
+      "contract_addr": "terra1a6uk8kz25l59krr2m683ph8l6waky0nphm5l66",
+      "liquidity_token": "terra1yxqlflppw6ldewgu6z0w5x4rmm588cjckvj20s"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1g0pm8xm5c2dq4qtv8j9a80hg4mhe5ndy8qad07"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1gmke355upsxhn09qdj9mvgdah24dhv4r0la4k8",
+      "liquidity_token": "terra1lx4m3zgefzx5mj872j7zg3q9qn2tg5teq9tarl"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1g0pm8xm5c2dq4qtv8j9a80hg4mhe5ndy8qad07"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1mjhrlgwv8dnvc7mp0cynfxna947hxnm5m4tp6u"
+          }
+        }
+      ],
+      "contract_addr": "terra1qr3jrdwrkqhntnkpvx39efrmayx45ysuhpg9qk",
+      "liquidity_token": "terra10fad8fupsy82nwdpddc2yqce2pmzfy6xy5ee8t"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1g0rda5pawz0duymd37puescqsx2hgqu9hgrp8h"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1kafq6reya5v8ksdlnpyzv5gnyax3l3vp9l79wd",
+      "liquidity_token": "terra1g95dha38ht2y8qchz2zqa0kjnr372zpgsyyejx"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1gs2pykgl27l04e6lprgqs6uwlr7rm2vjcnya8g"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1kneyp2t00kehpwkaxml9w7dg5p7nl703dv65vr",
+      "liquidity_token": "terra18p6hxmks8pcvpvju8hlke3mkrsfwjm5v8l3x0l"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1g36mr60pqf8x4hr3ulpsptrg84w088m0eunsw0"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra13r4plx4hme32jmzlmsyah9ulewyrq56krxh84j",
+      "liquidity_token": "terra1qje7t49vxtulwq8lw5re455hnj3r266uc7lquh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1gjuhc34ccr6ajq7dm5266xyedu96sgkv4qnley"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra15zfs6kf7c0f8u4layzwnwkzpqnkj8lrm86q8un",
+      "liquidity_token": "terra1pl38m9mkneuu6z9swzhvfl7gd50jf7a88meemt"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1g53pyke8jtmt4lwvk4yl0xaqc4u0qlsl8dz3ex"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1p4jvensmff8knpp76ej35ugaj2l75yrk5aufux",
+      "liquidity_token": "terra1k0q9wnqs4c8kuy2gudva5dl3cucf8xqxfjwsek"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1g5unnjllx9900hjsx6x3zhhv504ssqktdc82l5"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1mmc2z9znnl92338yquuhwzh2vj7gt9ez66nnt5",
+      "liquidity_token": "terra15hnvcwq69maqesv0497f45fez0lmunmghjqmwf"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1g4x2pzmkc9z3mseewxf758rllg08z3797xly0n"
+          }
+        }
+      ],
+      "contract_addr": "terra1gq7lq389w4dxqtkxj03wp0fvz0cemj0ek5wwmm",
+      "liquidity_token": "terra1jmauv302lfvpdfau5nhzy06q0j2f9te4hy2d07"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1gkfv34wapjun9w0qpg8f245greudfguzlhp87f"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1dfv0ww0tqu432aa9z6r0npucjyslu356602ayr",
+      "liquidity_token": "terra1n0hxydmnc55rzs8kyvefpj0xkp0524wc39euwv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ghtspakevqnazc3jtceag7uc3tnjujs94edlkf"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1u4je05rr7galjya4pn2c6s4gutg4evmt9qlxl5",
+      "liquidity_token": "terra1wfms03rc04cdc0xvs7rh8z3s498ns2zgqctq7y"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ghnll5fz4n6c0vt47jdnnyrjgfg4fgnqnchwys"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1rre03e5p2w39uuvgxpxygnmtalj7cu7sp540zk",
+      "liquidity_token": "terra10n748ua6aktwge5387w5gez45nvava0dzn2r9e"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ghkclqug2jhanmjsx46x0vymcglchcesg98057"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1twxv2kaeuyf3uxc6uzpgh3twe4mtagzpmn6sj4",
+      "liquidity_token": "terra1mdxxn3jy7d7h9sv4plk7qs5lk3l9fuyv2m7yu8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1gcfdqwp2ztyn22mu845n7axlua6nwt38s4nkdl"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1xw6yl2vhnlusw5gnj7l2mk0em80c2mw03n9ny0",
+      "liquidity_token": "terra1muk54uc0pqjwe6w26tpwun0x55ncttnadxrr6l"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1gecs98vcuktyfkrve9czrpgtg0m3aq586x6gzm"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1nuy34nwnsh53ygpc4xprlj263cztw7vc99leh2"
+          }
+        }
+      ],
+      "contract_addr": "terra1s47rsyk3q7h8ketsuw2swdtgqr4lqfvt9jfdx3",
+      "liquidity_token": "terra140a886v0e6nl8s8gpzkrunk443pr0venvvt32e"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1gmpn6gy7tdm39tc97te2f5prjdpgml760pke8k"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ukrw"
+          }
+        }
+      ],
+      "contract_addr": "terra1r9e7efml7zk8fd5x5atk39e8jua9kdt7n7lp5r",
+      "liquidity_token": "terra14dgkwkplgmw9tkdf4rc72ppk6q5p2mu0uhfl09"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1gun7mcfjq965gm2jqmq2upxkeqd2lay4qrzfej"
+          }
+        }
+      ],
+      "contract_addr": "terra1gg0snqxxxhjcma4095nn7lduwtv3k5xw34lzks",
+      "liquidity_token": "terra1f7jzky244gwy220xp7cdd0vzhu6l5ncafderaf"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1gukawnd63qd9ptuqe0ejm0vvweql45084lx4pq"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra10apggvnqewuu3zg03l8nzqemuwtnfhnsp7pup4",
+      "liquidity_token": "terra1y02yk8gwl7efuv76le3lrct9fn3uzs5a7nq4xh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1gazefv0j5m0hhalp0qea5smypej2r0matncl88"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1yz9qsxe70p6j4vdhrmsg45gs858lhqzxq3dgh7",
+      "liquidity_token": "terra1peprsfuh0kt3xz8zgjmy9rfgx40jpf36cp24sa"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1g7fa8wpfp56tzdd5mgz5r5jsvqw7hm5e3tdlnq"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1yag6m3d3q60wnhpd8fm2qhn4uhkzpufazwz6w9",
+      "liquidity_token": "terra1nl5wp6j8tna08ymthheynq0u0eam0gad5pgxku"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1g7a07e0fxyhajd0vy3v7kxt54txpqdulw9rtzt"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1yw6ehsd427k6zs4978a6dh892xmw2xh8kpfccn",
+      "liquidity_token": "terra1al5hr0pvrg4sg326kmh8zhhj4xsqhl8ckqdqhk"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1g77epr507pp572hnhaprjuz9fp6yn3e4mgyxar"
+          }
+        }
+      ],
+      "contract_addr": "terra1kgcv6dq7ajlh98t34puyexhy08ltnnx2tycrtu",
+      "liquidity_token": "terra12vd39hfjd5gtn0a3t6jy0xsy99k2kcvlcw6gcf"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1gl3ywddjkukupa3qv86r8xy434frncmxna630k"
+          }
+        }
+      ],
+      "contract_addr": "terra1k2sgkcw0z5drjcy4nl09v40xt6hgf0kpcm4rpc",
+      "liquidity_token": "terra1v8qcdlqarhhwtqm5fl9wxfrg58xmtjnka0dnvl"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1fpfn2kkr8mv390wx4dtpfk3vkjx9ch3thvykl3"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1cds3ru8n9s6cpuqszd6kupxjghj8r8rqk8jvmq",
+      "liquidity_token": "terra12vugedn4wdhxztzaycucs4cn9l2wrqnq4xr4f5"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12897djskt9rge8dtmm86w654g7kzckkd698608"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
+          }
+        }
+      ],
+      "contract_addr": "terra1ht8f0pnym9tcnt5srxmlnyndsfl84nntphqfsl",
+      "liquidity_token": "terra1ku5mkpj7nr402ncduym4mgs8ggva67qcjw72hd"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq"
+          }
+        }
+      ],
+      "contract_addr": "terra12wfnxnvzd9fjt3gyw38mhncw027n2kd3p8jf2x",
+      "liquidity_token": "terra1s3v0ftwx0vuhy9482hudf5z8u0vsmrkn4nremh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ukrw"
+          }
+        }
+      ],
+      "contract_addr": "terra1gkrajyr342clv98p2f6dx72eyj5cx0t9pa74f3",
+      "liquidity_token": "terra10q52n4yx9nn7p2arhle32kyujt65euzh3vny4l"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
+          }
+        }
+      ],
+      "contract_addr": "terra1kytqskj07g0d5qwk3jr3l3z8fdvzjytyntda9v",
+      "liquidity_token": "terra15mewh6pgu8lvwjvyp692ez0yfu386mtydw3vp7"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1gc46an30tdv0n25ch5twgzcsw0wpk2h32gp4nq",
+      "liquidity_token": "terra1cx9shhtqmxcacs8jhcdgxce8hqum2u6u68d0sv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10f2mt82kjnkxqj2gepgwl637u2w4ue2z5nhz5j"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
+          }
+        }
+      ],
+      "contract_addr": "terra1szj7qd0azfzf4sarhxr2wfzf0k8js3vng545cv",
+      "liquidity_token": "terra1p3urvqahfp6pup8xw6lp3zcruw8kv3xrkjwk4l"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13awdgcx40tz5uygkgm79dytez3x87rpg4uhnvu"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
+          }
+        }
+      ],
+      "contract_addr": "terra105yxgufwjx5gsapk0n0rkea0dxvykyujx379g0",
+      "liquidity_token": "terra14z7t45phqgnx67n6qdvs4ac4cwy0rvflugzyew"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1jx4lmmke2srcvpjeereetc9hgegp4g5j0p9r2q"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
+          }
+        }
+      ],
+      "contract_addr": "terra170athjxhauwzdn3tejfcv49pej3atyv4qwffrm",
+      "liquidity_token": "terra1xhjavlxlfwqw2w5hj4395m7stl4ut5zus6mn4x"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15pv3xxp2d5f65qeu2v27vqf9zpqjx0fuztfwcu"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
+          }
+        }
+      ],
+      "contract_addr": "terra136vrkx8kq7x5w0kgklzh9vxmn2x93q0edqe3nf",
+      "liquidity_token": "terra15uzdzdpv7gfzl84yhx53uz6769krhf6krd3s7c"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
+          }
+        }
+      ],
+      "contract_addr": "terra1dcs9ja40rmdax9g4ffc756w4cf6yvrf4auxye5",
+      "liquidity_token": "terra1wn8t6kcaqhxrhtexkctyfaftrtvczkkh4u4p5w"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1f9h22l730vxxj5jmrakuwh3neuhdynwy42ezvv"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ewyn79c2nnzp7g57a54vv6l99lxcjdcd4z770n",
+      "liquidity_token": "terra1h0lllt9mecr69e4r7qs8jtnupz6vnk30l87egc"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1fx98eqk0q9fta4pkex3ye786cckcx8y65qwu9k"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1uzy7ultsgqj9g780dclpg9jgqd8l73xa8n3fj5",
+      "liquidity_token": "terra1ny5q3wxlngmstz93r23h0supvydx2gqjark2yv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1fx6ffswrmgyuf5nsxruce5gertr8vgsm7krrp7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra15wltkaszz098q5fflded3g40xfnezs3n0nd9z8",
+      "liquidity_token": "terra1kgr3ez9fdde7czgfttl7s20r7gt6aw8p95y2j0"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1f887h6wqygswcp4arjjak6mpdhwlrv6nj8y9wt"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1rnenevclqn95uhszznh6v25gaqswfejsvcatu2",
+      "liquidity_token": "terra1gmvqnsr262yea2ltxvv6qxqgl26jsl4ah0cw2y"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1f85kt39ar3tkscq6w8ylxv2t9qh4ktzayw35ta"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra1y6x737xg3q0nrqfgjkzy9ggfjmanu7675vva8s",
+      "liquidity_token": "terra1td4yfemjtq38lq98vqhnywfmjec979z8qxqrx2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1f85kt39ar3tkscq6w8ylxv2t9qh4ktzayw35ta"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra10fkdl22gefrydr762n5gah45du54ykwgxw2smx",
+      "liquidity_token": "terra168j6qa84dmcuamp4pv7xuudgp96884ktp3cxuy"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1f8m2ylcpzfeg3675yk7htw90d72jltgk4mkr9t"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ehdk7m3p7fwpmzhfh8pdnqueqy6ymmccsnjpsd",
+      "liquidity_token": "terra1lxx00gux7zl549dj98cd0rws0xv48ns4qdf2zf"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ffute26m0e5uq3wmzys3452dge62m99u0xz30u"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra18dtgqxmc30g92pshm2u2pj9h64q2v4snqh8tma",
+      "liquidity_token": "terra1h70xcjaq5a4p4r02qjwqgvvpe9k5l9aafnyelh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ft9qff9fgumdca5qluxu3e8fh8xc7d4hfek8s2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra10qeuxxj46luwqk8huh4gcp2r0ve7w5vh3hrtev",
+      "liquidity_token": "terra1nwrrs5nt2klcspvhtacsru03g5mzsxvdx6p8jg"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1fdg5u7nttkcw2v4sepgzlwsznfffn8pnml35pu"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1wweezy8awhrmqtszun57zh2xh5yat4pndv9ejz",
+      "liquidity_token": "terra1fxzmf732l2mj23wq3aryww50xg7gclhelvs2k3"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1fd2f52tmq59mc093nrawdaey5mzgjnwyu7hwqz"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra13l96rf63hd9ysruu9ma0vpjwwnjuk4e05tj7xy",
+      "liquidity_token": "terra1f6jappjsusascekd2uk8djncfwsh6ygp07h7mq"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1fd0gy7f5dcgmvdl95mt3z9fh8se48gf0wxs68k"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1jccp3z6efd6r4f88p7ewy2qpjtahxtz3glqu6g",
+      "liquidity_token": "terra1lk96dy8w7cq4x09q780cfg7wwpkuxrxtqjpycj"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1f0us6p9axmzacwq2fn7sm5ke8k302tx7hg7s49"
+          }
+        }
+      ],
+      "contract_addr": "terra1gs8pm90pllcz5t7hsqs2fnxjv6pxzf47gg3eua",
+      "liquidity_token": "terra1hrrdpncsr6z978kekdamdaw9jrxjr5r5qtsdas"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1f3gyvkfwy6lvst5c63gx7alp6547clceaamyyp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ktsswe96kkjwvcx8md8dt4k8szt2wkr5fh7px7",
+      "liquidity_token": "terra1npak6kyfz07etkg7hk027yge7h83pp2h5u0t26"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1f3nc4md37vcy9l89qte2p5tej42pr8rzch8mfe"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra10jnrtfv5vle4gdknnu55d2p8trd6lxzwc5shp5",
+      "liquidity_token": "terra1v7wyvflxcxchx2zxu2n7e858wlx9u72pkku3hv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1fj06x3hq2xum56htlrdeame70knzl765cq4txr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1h7zyvfmu3fqy6ew43c38t0f3p795c8lyyghhnf",
+      "liquidity_token": "terra126pa5vgw2ca80yd8gnk4fs08ef94g6j2f4kjcu"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1fkwfm2w8kffl3ged3zulknz849rnfdxnwjgdnk"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1cdj55x2gj369g50g3w2uqjm6p2fchgy2ehjd0p",
+      "liquidity_token": "terra10z27h35npl969tp9d05qfs49k925rxm3w5sd96"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1fhsljj6qc8f7cnu62e8uxqt82czflztge05dwk"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra14u4v5ms29m94jvu2nn37jep35frmg5u6a2qw8h",
+      "liquidity_token": "terra1fwx3235vfpcwkv68nu2vv0cm2sda3dxtdtnpuh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1fcq75y4ezhsws0vudna3cddk20d3k0eg9nznyh"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1fjrjynsdxvgqsahquuun46w440d59020vxva9d",
+      "liquidity_token": "terra1qmkvvy88csy36tdqcknlw27h0vyqg9s0jph4zp"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1fc38stp3xzjh5q8u0nrlk4n0gagxrnen35rsq8"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra12guk0mlt4jknln7mu8y7kjdaglqehu2r2kk6d3",
+      "liquidity_token": "terra1jcu9exrj6ejq8a4u67xf9htmrn2dup8gg9kwts"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1f62tqesptvmhtzr8sudru00gsdtdz24srgm7wp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1sprg4sv9dwnk78ahxdw78asslj8upyv9lerjhm",
+      "liquidity_token": "terra19ryu7a586s75ncw3ddc8julkszjht4ahwd7zja"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1f659ez3nysf06765jjjqnl7m65urrqaxx2t40h"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1cpmqngse0kw0rkgv5pewgg8dvg9ep240xelxc4",
+      "liquidity_token": "terra1uzzyyxp6kj87q2ygm0d9se0pthnrjh7jy75jxd"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1f77l2dprlhg2h47uvhzp2zhkdrkcy8fse90xkk"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1yypalnanxp26u5uypunlj7mwx0mrkrfw3juqtf",
+      "liquidity_token": "terra1dletuefu2w56d4nptmtptrglnxm0vf4snm8l32"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12qr3vqxznkjtyrgyrhluh8zlcy82cxv2l92rgh"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1agfsk5lyy333aeasfv3zzm8n9f77k5xws7hyr8",
+      "liquidity_token": "terra1vf80zzn4s2f2xl2vkyz6xfahqh9y407z8al8xt"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12qxyx2l90c37kylw4jqe8t40ppnrnu8wqmx940"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra19073h5d7rczrnu49r8aje5yly5llenv878eekm",
+      "liquidity_token": "terra1k67ut87c2up66tury4qc4n96d85t43u20v24sy"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12qgpr0fw773gc8lrkys3knnw6nkgdlc8ggaty9"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1a5s9cgdzw4pz4nf8rxyqp77q0wuegahs78tpfd",
+      "liquidity_token": "terra1pgyxxsnn08vgaav3a8yc77jh3sl0st8typpylc"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12qeh8p79q6jrnlmw09hvtytv9e99yl2077cmgz"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1j6dx9d05sdpynkxexvp4jqdlgqv2adp7uls4we",
+      "liquidity_token": "terra1da9qfgpar8v427x9me632qpk3jna4q37z2asn8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12zzantsa5trfm0ssrgsnhvlram502ats35qtc3"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1c3zsqpvlev8x70cmekqxmqjjamvwdw93gzqjlc",
+      "liquidity_token": "terra17xhypskf3f0cqf0knvyqw844vm54fg2j4fxng4"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra12y2uzvrn3j4y5390kfljtpq6z3wqflyg0wls2z"
+          }
+        }
+      ],
+      "contract_addr": "terra1g39kq9n6qmjzpls9kfxu86yvcz3p9ajy8fqjp2",
+      "liquidity_token": "terra1da3m78cejl8l396gahuqnllwl4qyxeeysm5vrq"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra12yvwzt5ayh396hgmyd0rwnamgg4g3mxrdgg7c6"
+          }
+        }
+      ],
+      "contract_addr": "terra150jz4237l3dfhhpppdrnz78hp0kw2ujqczf2e0",
+      "liquidity_token": "terra1vheyufspfcfh3ka9nafmxec0lwzls80cuf3sd7"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra129796y06jrejsk9hjmvhkhat92mxt76k6qpyfw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ukrw"
+          }
+        }
+      ],
+      "contract_addr": "terra1wm0ht8upyxy6lkn236hmzp657m58wlwsahkgn9",
+      "liquidity_token": "terra1fa6hue6yjt90ytjuxqv6mlsmrm2agc7w6vjhd4"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12897djskt9rge8dtmm86w654g7kzckkd698608"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1hwaaf5sj0039qf80q3e5cce37rw6kgdce44q0f",
+      "liquidity_token": "terra18kvjp6xw2epma0vlfpktg6l7kuztzexl3nc0me"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12897djskt9rge8dtmm86w654g7kzckkd698608"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra163pkeeuwxzr0yhndf8xd2jprm9hrtk59xf7nqf",
+      "liquidity_token": "terra1q6r8hfdl203htfvpsmyh8x689lp2g0m7856fwd"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10f2mt82kjnkxqj2gepgwl637u2w4ue2z5nhz5j"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra12897djskt9rge8dtmm86w654g7kzckkd698608"
+          }
+        }
+      ],
+      "contract_addr": "terra1zvn8z6y8u2ndwvsjhtpsjsghk6pa6ugwzxp6vx",
+      "liquidity_token": "terra1tuw46dwfvahpcwf3ulempzsn9a0vhazut87zec"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12897djskt9rge8dtmm86w654g7kzckkd698608"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1nagqpmyw55yjphea4rhntlfv87ugmeaj8ym756"
+          }
+        }
+      ],
+      "contract_addr": "terra1fl3x3plfat8y82c9wpu6uv97wkqap7lp04a4jr",
+      "liquidity_token": "terra1punuh0ts2fdqmp2zlzw6cutr9vfnpxvu56ehel"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12897djskt9rge8dtmm86w654g7kzckkd698608"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1u553zk43jd4rwzc53qrdrq4jc2p8rextyq09dj"
+          }
+        }
+      ],
+      "contract_addr": "terra1580sp4lade7khxntaq8856we6480p4gg6xrzw7",
+      "liquidity_token": "terra1nrs4azly4lur2e525pfalvucf5vhe4vgh4htd0"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra178v546c407pdnx5rer3hu8s2c0fc924k74ymnn"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra12897djskt9rge8dtmm86w654g7kzckkd698608"
+          }
+        }
+      ],
+      "contract_addr": "terra14zhkur7l7ut7tx6kvj28fp5q982lrqns59mnp3",
+      "liquidity_token": "terra1y8kxhfg22px5er32ctsgjvayaj8q36tr590qtp"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra128vws7v3ruqpysj0wwy95nl8a7an7nnyctmvle"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1q9lvy34kjnwr9552yd3thv39nmrwg7ej46cvy7",
+      "liquidity_token": "terra1f0l9d3dedr3au4frre8uc7w7s2chs73a9xqwjp"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12gsrt6nmp56x0q9t9h47frgr8praqyaqdvpaan"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ky57u0437dszysa0qchyxcvuxs6ax9f3p6anrv",
+      "liquidity_token": "terra1nq8x3tc9gudc99pp0j58n2q50us7al8v0y9eh8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12fctlld90cakzkuhd2c3h246zxrhwqd6kp546g"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1yeh80vf0yezluv2u5nc6e5n8d4phjy4c55zvg3",
+      "liquidity_token": "terra1vtz8425zxtpm8sng8u3grrdq5cruq4zeeh0cn8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12flsr4mk5sxmu8yk7m8zc5f44tfx00yjvzj7v4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1z3u6mw3s20kt67ts9txrg2mjkzcwt7tgasp7gw",
+      "liquidity_token": "terra13wlheafzjwwgctnxh9t9jr0pnqejuu63ykr36w"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra122anargqcp9anz2cmuwc3u5m4nww6fpvyc39tz"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ae0jhhxlwx46xp9uf9cwlca6pm5wa79wf8ppgj",
+      "liquidity_token": "terra1nannmaymqrxt00ya03ytfkhr027zrrgckuq7fg"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1227ppwxxj3jxz8cfgq00jgnxqcny7ryenvkwj6"
+          }
+        }
+      ],
+      "contract_addr": "terra10ypv4vq67ns54t5ur3krkx37th7j58paev0qhd",
+      "liquidity_token": "terra14uaqudeylx6tegamqmygh85lfq8qg2jmg7uucc"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra12wlcu0kgdfrfutjydvvcmhlx8jrfsqhwqarc3d"
+          }
+        }
+      ],
+      "contract_addr": "terra1quwpd8khrwhuvqqk42mfw0q56nh524gu5zm294",
+      "liquidity_token": "terra1vawsn9qcgq9dcrjwldmqtmp9pj4373eapurm0j"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra120v2mhzge3mxat8nsz8ctqgy6f0cnnfjymsgum"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra10rqw6xrzq2y3whp2r9q44zxyu5f8cdk0f4qa63",
+      "liquidity_token": "terra139kpcz9239c35dulyqkkyqsdhnx99vhfk6q4fe"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12j5fqlxaurnvxr27dfsg2lku57rnmgqs6nm6ja"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1jzkzn2hdvlq2d8lr8rj77r5lsqckxd0hj52mek",
+      "liquidity_token": "terra1e3fdfzrs0dw2tr9hkv8r3d649rydcwrx9zhum6"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12jhul3zlafuvl4fd54pvaax4ls872z8p06p8qv"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra160vz23qwte45w6dcgkkae05fqpap8l4s4alaax",
+      "liquidity_token": "terra1dun3ne9rhwz3u7m4q2ddsnwmkaqkf0cf65zd9f"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12nxvzzqv0yeh80z6eya0gcufyn36ntrkcalnjl"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ahlfw40ruca9h64e2hylwfs75ems76mnfstv4x",
+      "liquidity_token": "terra1079zf52uyn4hnxdrst38fvd9ga582xcjrmenw8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra124zh80answg0srxqynl8syswgsjx0heh9txxw9"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1x8em0g87c30a3s5hqp4ar3ad732q7eclftwlwm",
+      "liquidity_token": "terra152jfl6s4fmte2pe8ct0f0wtdm2k3xu6uesdfj0"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1246zy658dfgtausf0c4a6ly8sc2e285q4kxqga"
+          }
+        }
+      ],
+      "contract_addr": "terra1lvkkwhzgchq9n9xafag9u4q96q057vge0q87zd",
+      "liquidity_token": "terra1snem5zhmzj3q4wzm59tf98f0czsf6hcfpf703z"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1247nlrmskhfu9qpg66zt5w6f8cw250878enl9g"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ek0rr6pj76mtrukw9l90wd8xwcuknw8aqp48sj",
+      "liquidity_token": "terra1hucpvv7d9nqydwg86nyk2xrz4x44nf839zjyf2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra124ldhntd576t23fgzmcnwxpa2tgcvjyrwa9hel"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1qe5ttpmnj637t598garnz4sm0ma7jj7zm68s0z",
+      "liquidity_token": "terra1exk73v26tw8gspx3wawvvhl5j4uzaryx0l0uwj"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12k6ua9et2dnpmmq2rgz0wn0ugzr9jtyps5l8vt"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1pksem0e9s7xdjf08j9swuyr5m677660qhyhuqk",
+      "liquidity_token": "terra1saxejc25jretqgp4z6wj9me37qx8zg4lgzrmrx"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12hgwnpupflfpuual532wgrxu2gjp0tcagzgx4n"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ueur"
+          }
+        }
+      ],
+      "contract_addr": "terra133308rh6p96pxw0cztmfln8av2jkxnjlfvfcyq",
+      "liquidity_token": "terra1nz7ualeu7fcdayv64nmaypdd6e4hda9tgl502u"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12hgwnpupflfpuual532wgrxu2gjp0tcagzgx4n"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra109wt0lvwk560kjpdhuusj3a7ldnzasv028gmvt",
+      "liquidity_token": "terra18tc6j7mmqk6fwt38la3uvespuxvefkw3703xdx"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12hgwnpupflfpuual532wgrxu2gjp0tcagzgx4n"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra15sut89ms4lts4dd5yrcuwcpctlep3hdgeu729f",
+      "liquidity_token": "terra175xghpferetqhnx0hlp3e0um0wyfknxzv8h42q"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12hesat74nzz6av5hw2c5qxxqkhafxsgjhgnd6y"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra18z9fg8nd7dvccqnmyhy2p5t4pdak9c8j9qkr4y",
+      "liquidity_token": "terra17k56585u8yu084060vjlgf4jgmswxahguee47n"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12my7hcmagykvrem4y83nudfwvz58f7grwzrzef"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1evjyxl6jfzh8mf3p7vvv66ntxm4tvnx386783z",
+      "liquidity_token": "terra1gt646s72zxxt8wewy3l6n40m5ysnpee5ku30hj"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12mvfnsk4r2chx7n032aztme7zcypyla5pllhzm"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ex4tn8m3g2c8xv3q9q5mlm0d8aa6684g40y3cx",
+      "liquidity_token": "terra1cckk499jtsquglucsygqj5gxy9k7fu0vgwxgrs"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12a39fn0k0duteqefme6zgr5efg0g5ya7eglvyu"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra17jaq2p66s2n40wad52mfudk0z6u5tmyanhkc2g",
+      "liquidity_token": "terra1rkewqq6kkvpp787ltvpeccvz4qsqh4w7fv57xj"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra12lvpnlphqh3q0cxp8y47e5km8k2ad5ydw5asu4"
+          }
+        }
+      ],
+      "contract_addr": "terra1vfk7qfdchgjadv2l2rgmkfnswe5n277kwcjafk",
+      "liquidity_token": "terra12awas0yfsn4r4ppzp4agqu8rp8gyw8weglpuca"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra12l53n0hg4kh9y8jlafd7lyakj3lrejedpryj7s"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1xljkuseertrcrguycjwvqhht22u75epe6hdcxr",
+      "liquidity_token": "terra1s4jnf3gaw27ju6x9jll7sar06e6m2hj5hklmsj"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tqjzureahwdezhy64uw7x9vpywgxvxcngexecf"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra124rkw63yj56t38c5y2kahfxm5cwhl8s0zzma2p",
+      "liquidity_token": "terra14cee0hdd45fu3wwvkw5nr942f54dp0jsuta203"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tzkc6jejskv5qnqfa866qrlltx4240n3hwpeay"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1evjf2hq2w6y9t53d2fmxrfddauz8manutpykp4",
+      "liquidity_token": "terra15g2lqpqvv2zn3hz63q2m26vfle3vlgj6cqvny8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1trwpus7qwh4uhy9q4da9d4av3tmkj9lya5gjqc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1wua2tm7csatcn09044n3w6x0lspt2z29jaspgg",
+      "liquidity_token": "terra1r3ukduknfq3955qw9teqscdlpmdffnjys9hnvv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1trmdfczytlncankk89zzwpdea5gyvjt972800x"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ekjhawpez4jnf46fx8kyxsut8r0ewm64339cpq",
+      "liquidity_token": "terra1sj672lnz69h5rmffjgq808jtkx8c6g0c564dhs"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1t9m52s6gey6mcy9upq5ucujl5n6ewwqk80hp8t"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1wwtdsvlakd9dxstp85vyawrh5t6ftjuuqern0n",
+      "liquidity_token": "terra1kucdkxvceeue4lknqdjc49jazkuw3hmx6jqr2l"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1t9ul45l7m6jw6sxgvnp8e5hj8xzkjsg82g84ap"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uchf"
+          }
+        }
+      ],
+      "contract_addr": "terra10xlgqrh0uhc8tt50wwqv3peh9w5zjjq3cz00n0",
+      "liquidity_token": "terra10q7p02sacknlxay0a26j7fhm75xryx2jppunwj"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1t9ul45l7m6jw6sxgvnp8e5hj8xzkjsg82g84ap"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1r3cjla7hlktc4vfa0dmzz8489e88k67yxjndpd",
+      "liquidity_token": "terra1w9pj93rwhtdmf37rgfqntpn77h2trulr9tlc5f"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1t9ul45l7m6jw6sxgvnp8e5hj8xzkjsg82g84ap"
+          }
+        }
+      ],
+      "contract_addr": "terra1k30c303e059kqhz705a77kgdhr2ndldfdxjvsr",
+      "liquidity_token": "terra17m0ujjyw0na6jmjspl7ykzzuu675c67rl7m9gl"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1t9ul45l7m6jw6sxgvnp8e5hj8xzkjsg82g84ap"
+          }
+        }
+      ],
+      "contract_addr": "terra1xzvpq09m55j906t6wzudtesx5cnj9u5ks7eegq",
+      "liquidity_token": "terra14cxm2mfaajuvu2c9vqc8kqr7w74l7deet8ewl9"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1txlylfvu2s9p3tt2fa82xj6qy6pp86avs0t43w"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra10xyreshk74gx9ygw4q4j0m9pr9je4spzas0n5f",
+      "liquidity_token": "terra1m9dlyzueyqy3pdl3tzwn60lc7myhum7j0zq5p6"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1t8wkdq7kth8ngxgrpltwam0gv0h88ajh0get5c"
+          }
+        }
+      ],
+      "contract_addr": "terra1390zekgvzfwdvjfghh9fxmaxq4tzfzux59slpp",
+      "liquidity_token": "terra14uuhfjnxewphya674fgf7t0g3cn32uryrgkm5k"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tgfw423t34rwaezm4u4vwy5d80tfgzuyx2s6x0"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1s5w4yymch3y85n54pma0qkuyqek0s5a9kys39k",
+      "liquidity_token": "terra1svwqdq0gcuw2q2vzmy76qjvl2pnwaz65d4xvs0"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tgv52cmga9s6ymah2efz877xlpc4v8phq7mn69"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1tg8yu978lhcveq9j4emc9f7agn00dvecvx4wju",
+      "liquidity_token": "terra18c9war4ldlccnast92snzt78ty378e0ggh8a8j"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tt9jmf58nvaj8l0lckwfekfl43verjdpywcdwa"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra15n30h56p9zva8gfp7ejd0smw2zf5xlxwelgg95",
+      "liquidity_token": "terra1grmmss2wq0e52uz77wudxfqdgwt6gxqmdrvajc"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1tthplnk67e7tvga2dh49jk6l6cn4furuuffu9x"
+          }
+        }
+      ],
+      "contract_addr": "terra1jvhqxjzezxvss9d0rfpttvz4hv6lp7urvwmx0j",
+      "liquidity_token": "terra1whdv289y72n38x8sevz5erze8zys493ha2fd0a"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ttm7w640scqrarn0qxqz26798d84u94sg7gshw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra127zvfgggng7zx3taaj8myslx28rrq28ffycqxp",
+      "liquidity_token": "terra14un4rp20aqq7h07zpgzxrz2fcwsplj8jp0jham"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tvs43r9ry6s6g6j5mnmruw97s3fjhqxpc540hu"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra18atry8rvvpu35pp2tm87exk7y56jm2yhza4fgp",
+      "liquidity_token": "terra1ynzjmya27v8f2clle2dl5vw909ffxqlkxgcyfw"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tdvvjf700gerwvkwncjc7nzythdewstk47ah93"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1558wqfc8ffq37qj3cjfkgfj6r5xflh7gnfytw9",
+      "liquidity_token": "terra17ntlqfva06ga9jdmz0t6mhqsmvr5lqrekrxnug"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1td527f09l7lgf55fqtr0zvtx5ek0yl0fdrx574"
+          }
+        }
+      ],
+      "contract_addr": "terra1t4z4tdtn8ka6q5g7x3mx4h5w8ufh07c3s6eca4",
+      "liquidity_token": "terra1n8fwsrf3qruwx99eg87dmw7x4pjc8n0a35vlef"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tdc7hmydg3es6lmn2asfwfgs8ykq7xa0nz9rkh"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra19ypukqk0v8l2f04qjsc9pwullq7r24eufm6led",
+      "liquidity_token": "terra1yhlgg0kkm7vngmj68suf0jmx5fj7v7hpxy4udn"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1td743l5k5cmfy7tqq202g7vkmdvq35q48u2jfm"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1dqjt2jm908qaayw5hdl36w50sshmgem37suawr",
+      "liquidity_token": "terra1lzacmnuaceg2578lpxemnx5mts5es8fnf2d6u2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tw845kgt0uq0gfmavawacfvaq5t9fa9v57g6m9"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1sprcgsnem4yrnzjd67wunkjnvndjr45jme060w",
+      "liquidity_token": "terra1aa22fmunt253n4hmuerm7p2jmt08trj9l43ne2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1twcwynuvhs778m8x46n7e6gyvu7srtkjcaufxd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra18gdjzd5p76dwywsqn7kgxsadfllw6csghl37vv",
+      "liquidity_token": "terra1tnpd7tzz7nyd7a2uq2kcu0r9pue5fwmafph9qg"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1t0csdwp5u9592522n35ededwt2e46sur5u4mkg"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1sg6tzmqegqhacd6nkrkrxn6hy4lx59ex7tt6mv",
+      "liquidity_token": "terra19w95ffdpqeweglhzadwcaa0amu0g7m490kx5ch"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ts6qq7va0msf0se3cwjsppt3vkumkh3t6n4d8a"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1rx428v0rr62qcwd0cppz0xwj9qrh8zpqkahkj2",
+      "liquidity_token": "terra12awz2khk7ccyzfhstnzzgu5um4vt5yts59z4dz"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tj9zrn3myxvkct20ehzje5whu5j75c94s8r666"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra167d8as4vjhgn3m04x3jzl80re5sytn89lr8s2j",
+      "liquidity_token": "terra1em445q3t0ckevthda8enkd7v8v0wlncqyls06t"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tnp8vgurcuhtau0r0qjtsx3swmr0hhn6l8r402"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1qpp9arlwz0089pl60x9ymakjlcz9388efukxpp",
+      "liquidity_token": "terra1c46y73zxajxwk5lze00zce3sexafmr7fnkqxhg"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tn2upc52zce96qprewh0gk5thvqqtuhaz7r6qd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1y53r7wkxtajtsmn0zjqu4keqyd2qn5hv3ykmt8",
+      "liquidity_token": "terra1smfcvgpdggf8jp7p3yvaqs0jl25ene6rwynn80"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tndcaqxkpc5ce9qee5ggqf430mr2z3pefe5wj6"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp"
+          }
+        }
+      ],
+      "contract_addr": "terra1vlt0pfn4upwxh97mx3lcf5ea30d8crnfas3ra6",
+      "liquidity_token": "terra1djafc4tt54lrn323s4q9ad79pc0j98gzndtdav"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1t5r5ptw6ympy9npq0z7fa37nrk39n8054c6763"
+          }
+        }
+      ],
+      "contract_addr": "terra1k5gg6rjgmmut6m3klz0sz36x7lt505p977pc9a",
+      "liquidity_token": "terra1y848ua0mxnczs6hslk6gug8tmtx9cmlgf2ju7q"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1t5y4xm7xdc7csud2j2aezxs6e4uuj3lqpqk7jy"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1x6dvc72unfrdnrkyzvm8pz6kmugdzkzu66fd9v",
+      "liquidity_token": "terra16ut6d3kh5tw08lu9np7s9fqlxl0z3c2gpsqn64"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1t5kcd9285mqczsyy2ztu96h8h8ecpy5sf6h0qu"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ajj4klvt3gpf5mmkmlsaz7t23paaanm68xn9dj",
+      "liquidity_token": "terra1pg9ukye32aga2z8kqxdkdmyeyx8un6lhdvszrc"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1t4hgtl3uqukaas9lzswl9hr7d55mn3tq3tt3rd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1wrcvvmwcy5kfqlmdfv4jsekv4uxjxhyl3s8hk4",
+      "liquidity_token": "terra13p06gkedafgwg57fdhvsrxra88q6ydx97l55nl"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tknq3prjtkzttvx2u48hn4r7xfwh7gz9cxzgqf"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1dc84dhqyqrrzpt3tjnkrzsyky2yyzxr5tszzxw",
+      "liquidity_token": "terra1dj5q78dmy35a27dq97sl28ta78yw2qaz275xaj"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1thrmc4qul2e02y2rskm7583g6guvtrvc8pnlmx"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra19ak9slt8fmlv5p09j0y9edswgpvmk07p8nplrl",
+      "liquidity_token": "terra102pj92vh6cem9hyzyep465k0dw3ng4hqaaqsj4"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tht79ct6uqe4ngg6wwjpxcu4ep3wdjhlttkthz"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1hh8zw9ppkfrqg6h3lxft5qlz0svqhg2nwutmp3",
+      "liquidity_token": "terra1wjw2f93ntqtahv9unlwhx3jjzmmy0npnkjh6f2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tc7tcg8u54p3t2r5yfufgf4z340ggwpvlc2rwt"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra1aqd837959wjcpzssqqr56rhh7dcq2nrqpgqrdm",
+      "liquidity_token": "terra16c2lh2lr0xe92ayf558rgzw47gf8cmqh58v06n"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tewnpkjdtqq37udf5c5wjfrtkpegthfmls8lp7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1rwsyvg7e67rald7d45833nsw487f9mt2wk7a23",
+      "liquidity_token": "terra1lyldsl94d3w3jhcenqjwsp4cme9jufur8fahk2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tesjetjz6q7s2etc0pa93ep6fwhzqqtcvreccl"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra18cwjyccu8snhk2tknk962h2vdvnmerwhrn57cn",
+      "liquidity_token": "terra1xdgsm8apwxuxgql7ll5uc34h4w3y0tnywvsg25"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1teh62le6cndl2ch9yw5vkjk30h2fd4mhkrt5wc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1zgs5vau4g8kdccxth3pmjs76vpm3wf8e7xcem4",
+      "liquidity_token": "terra1smw65pxdtqr6p3w6zf8euzx2p4dqngauvjnlv3"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tmpe22c2kgfh25hpjmauvpcg6c0vufjnafh6j4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1rpzcmwkegu5nat5rkgrqh4u6whzejssul7dwjt",
+      "liquidity_token": "terra1tmsf9rxszx7em7c9qp6eljcnlp8fhedezs32ny"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tm2jhnfh6hmnpvzsyfteqhcn6h5uw2qafr48yh"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra17nntay5n5c7za2yzgrgfcl9jaytyq37qzrwg6z",
+      "liquidity_token": "terra1ydqalj4l3ztvn3pr0rmz42d6wam95nae2e2xz5"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tmar57largkrtts55q8szey2q78zc9em43ej5n"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1323sdyuhfl05jkhlk47ypmhtyx2chzv92tnsn6",
+      "liquidity_token": "terra1phcujfuv584t5mrmmxtag00pn36kscspec80gy"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tutdnkar3qn527z0ktlazggayacs2m98tz0guf"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1arr5gq2rzh2w0pc6ku9xdc8ken70zl3aeydw6t",
+      "liquidity_token": "terra1parss7a209646cgrq2h0nl8mtzdr04vj5h9879"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1t7apedqrzywmrl89feackcalpknfzu5mr8t3xg"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra10vpqzvhmy25pjgwkqt9eq22w3t7r7hta60gxgk",
+      "liquidity_token": "terra1y3k5urh9ahwzsxr08dlspds4vpywsat49aklvn"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm"
+          }
+        }
+      ],
+      "contract_addr": "terra1dl6h9np5xhtwe520ksjawy5q9lh4cznmhmzkw2",
+      "liquidity_token": "terra145423sy3utrl5fh403tj0gpka36aqwu0nvktun"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra17dh7ekvz3qeghj50rqphx9es33qr5z5c5dhgdz",
+      "liquidity_token": "terra1zn6ke73eyqvr4s5zsfkm2jx3ll0uk9aw8yd7pd"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1hngzkju6egu78eyzzw2fn8el9dnjk3rr704z2f",
+      "liquidity_token": "terra1t5tg7jrmsk6mj9xs3fk0ey092wfkqqlapuevwr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vpws4hmpmpsqwnz3gljn8zj42rv7rkpc5atgt4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra10ex2fzy8wwwykgcdl8p3ruvvh536f4mw8fxzzh",
+      "liquidity_token": "terra1dluesh3lqcgatxpcy4c4jg6hydkcc0echunw0c"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vpws4hmpmpsqwnz3gljn8zj42rv7rkpc5atgt4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1r96mse06m03de6jkx52ku45p36htc9zx8k89l4",
+      "liquidity_token": "terra158g4r6gglcsst7ddua65rzfvzqums08y5m5dym"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vpehfldr2u2m2gw38zaryp4tfw7fe2kw2lryjf"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1e4vke4x2tu4xuh6s9zz42rnvghgcuxqcm3t9qx",
+      "liquidity_token": "terra125gygqsnr8sv58w7y8nh2ewdcexxrfkae53pak"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vru3mk2ne3jqpwg24wm5mg2356cg5ead0tae2s"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra10l7zllh9hduam4tugygj9x3f6976auj2xeyegp",
+      "liquidity_token": "terra1ftd4p3rfcry6sgrwjs78s0562kmut3p6cpnq77"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vyenreh8z62r35rydtupkqnmjsalee4tl90vn6"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1rvjjnmeq5a9fje6r2guaxuezd7mhghk4t9cw4p",
+      "liquidity_token": "terra1l22rm7mmajqgxep8lv4nuwzvuj9xc0xahfe9lv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vyusa796w86yh99l67dpd5g3hfva759vyuhn5z"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra16l746rd5nspcav63emsj9uem7v7s7jflrf4mv7",
+      "liquidity_token": "terra1emk8xeed780j8extpdd5q42h0grdj0ad4ce849"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1vxtwu4ehgzz77mnfwrntyrmgl64qjs75mpwqaz"
+          }
+        }
+      ],
+      "contract_addr": "terra1774f8rwx76k7ruy0gqnzq25wh7lmd72eg6eqp5",
+      "liquidity_token": "terra122asauhmv083p02rhgyp7jn7kmjjm4ksexjnks"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1v8xzfedstujqexgz6vd902hppykuu2e7ar3pu8"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1qksw58xydjsqh9swyv764jptsdfskzx52qvalg",
+      "liquidity_token": "terra1eepaxpggqy23hefzwj57xtfukkaq240mrmlnm8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1v8wg6yr69cu842w053f8qk909f4swp4cn2waqp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1x5zatqdvtxkc6fz96h4zslfj4zueqr8rmdvfje",
+      "liquidity_token": "terra1crkatrwuxvp3348vjl42r3v8n59lqjpullpm77"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vg6wky3jm7qnr4w4qtw6hflhlhc0v79z9jvnxu"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1tf360u087hzhw54yymtat9wd5p5c9a3n5jvhek",
+      "liquidity_token": "terra1xcxlsvm6q2nk003kqnhhddfcfm7dtnze02f3yw"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vfhh44f57a72vaqdk69k2y9pllwlrhkv32n6nr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ntncg8wkucxyjrl25rd4ddct75vyqzf2yrxrhv",
+      "liquidity_token": "terra1qv0nt6fny8esnm2ga02kxy3v826u2v9rezalnq"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1v2s7gkylfrnwsdcx8s83k5475nj3jykzs9gsqm"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1z96yec8dxc6ummv5kkksft3agxmsaur07zxgq6",
+      "liquidity_token": "terra1fn7psza4kxrmu3vhnelg08629uapvmmr48xnew"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vtr50tw0pgqpes34zqu60n554p9x4950wk8f63"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra12mzh5cp6tgc65t2cqku5zvkjj8xjtuv5v9whyd",
+      "liquidity_token": "terra1hvz34zmk4h6k896t94vd8d5qjdchhnkdndunzx"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vtr50tw0pgqpes34zqu60n554p9x4950wk8f63"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
+          }
+        }
+      ],
+      "contract_addr": "terra1c7uxt89gap5gcclvhtqvx3wpd0ee2dpjhf0ct6",
+      "liquidity_token": "terra19umy5s6eal7kekrddw792wmcftxvsktc2wxzpf"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vte2xv7dr8sfnrnwdf9arcyprqgr0hty5ads28"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1uxf47plxtc9tj4lnfwrlah0xp04hhhquye0wcf",
+      "liquidity_token": "terra1mt0k2prm85vp937uevm9p2390j9f58plvk2m59"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1vdp45eqxknrreqm236nq9pfseaerl0ww5rdqmz"
+          }
+        }
+      ],
+      "contract_addr": "terra1pmnannzd6c5qszcmxu476hjrhj6yas2rvc7j6p",
+      "liquidity_token": "terra15hur887j6rz557m7plnsxcs2nzt7uut4lq9hnc"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vdpk5k7203r73fgl2ppwsg30vmtu5akgk0emse"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1q9cxc20mhr526qhrct46ucrwxywmv3daa7a36v",
+      "liquidity_token": "terra1fst9xfe8wv8jucvnn5afnsmkzqf3hu6yy2d9y5"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vwz7t30q76s7xx6qgtxdqnu6vpr3ak3vw62ygk"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1d6k2mnhpqttsqhae2hwu7rs78nrrwymeq8p40j",
+      "liquidity_token": "terra14ldgmqnhpf80attmgjcu6am76zzn8cd2ntkvpf"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vwz7t30q76s7xx6qgtxdqnu6vpr3ak3vw62ygk"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1m9hm6cxlf0907yy7lsssyfpzswlu54r99k9dxf",
+      "liquidity_token": "terra1d26gruswnl36rvlny8sltdzjvpew4nf2vnj38u"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1vwvpvamj60rtnzxzr00thgtv5hplhu55jx67d6"
+          }
+        }
+      ],
+      "contract_addr": "terra1haay9t8vvpvdrtd6t9c6pzl2cpr8m4xeadhykv",
+      "liquidity_token": "terra1k5z9y8h9jr4ex63cmmlazn3kjc7mncn66xrrk4"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vsr6l45yyqn58at6nymdx99kph9sw7zql70akr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1c586ncze76sv75zlg3cqusqdmn6zluukdhc9cx",
+      "liquidity_token": "terra10qpu5aajfmkucfft53hs6hzn96ckaqa0cdmhje"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vsl7etwe53vglc2xq2rdt7mujarcjy9j694hdk"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1a4cjrs86m97rk0g5yuds8yjd7f0en5drqnynwk",
+      "liquidity_token": "terra1mvdalcuxntt9jrzye3chf9xv6apr3dh9h2z5kw"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vjgnhlv9h0nlta2v7s5hts75h2mc065c6ap3j5"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra16s7w70jm98htj2v6mkhcx8uy03l7d4w5mjfnf7",
+      "liquidity_token": "terra13pnaneaclmvtd52pl7crf74dwvau9r9r430uk6"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vn8rmcu3yywfndh2ze43v5h2wg28rycdekdr6u"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra183kl26dv4ymz55cytumj77z5u6m383wgfvsrvd",
+      "liquidity_token": "terra10uz6jgxmj3ywj9xndsnreula337h05jpkzppnx"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vnkmt0cwd5k870ny0e2crt2yrkmj0cfd3sylvc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ukrw"
+          }
+        }
+      ],
+      "contract_addr": "terra13le0pfhey5ltg42z8e2cq2yt8jxu4ry3tdmwu0",
+      "liquidity_token": "terra1klgaa9lyrcgdwudd9mvu0ys2spdsxd8mk55ure"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1v58klw3jakaeas2dkppqdh4y4dzd52kzda2fgf"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1pm4gx7u354nlgjdz0xf4kxpx977egdt6z5naca",
+      "liquidity_token": "terra17tdq6g3xqmwpk3q4mgfl0qcuyz7sqaxqa3n0rm"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vchw83qt25j89zqwdpmdzj722sqxthnckqzxxp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra17gtlmwdasc0p8rzms7wzhts4nshu47f5xud05w",
+      "liquidity_token": "terra17mwkhsau43y602yev5nmgzjhel5jsen433wf22"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vchw83qt25j89zqwdpmdzj722sqxthnckqzxxp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ltjtvt27ra3vrhyfmv4x4wymez7kwal5tzx3mq",
+      "liquidity_token": "terra10g77x9yzy2tchs8d02tjrr3dtmt5qcq97mteqa"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1veke25wgg7xk34c3gxsweuxsdqajemr307e8df"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1632r5htxk5ctf4srh7v2teguz47aen7ygkvphr",
+      "liquidity_token": "terra1uz9zfvrltmy3gawmsedg790xjl25jpgdm6fl3y"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1v6p9v6dqaql0600hmdl78h592ax5rxmheefgd2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ddu6j495ephpxm8at7jzg55n6u0zc2yadvuz26",
+      "liquidity_token": "terra1cs0u86hcfau5shkdzx6ynyrhar7r0vlsua609d"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1v60qvtprpwt65w5tfamt4l4wpp3jk5mfeh64rt"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1u993cu7zuzsgt4el5f6qu235xw2shezrde393r",
+      "liquidity_token": "terra143szxpzsamn9x6z2uwjm58369n9dmzt2rr77sk"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1v6khrawqqa6pqhwa0p6a5dt2a2g05rnum5mtcy"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1fxna4uavhgfzwph5gcehq7ujjdm3n7fkx3zzph",
+      "liquidity_token": "terra1xkaf74084t062hacrp0eq5a5kpcr82qk574a5s"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vm507q46f2sm8jltjcvp3dtncttquwld0tfkdl"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra136x580v3ls69drpywrjmr0cyclpredk3l7923f",
+      "liquidity_token": "terra1x7l87ufxsfa6mj62gu97h0m07vnfrma2tf8v3p"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1v7q43s46ntt4p7cpxcvsxjk6srr7uxvldn6vuk"
+          }
+        }
+      ],
+      "contract_addr": "terra1lku3pluvh5hgdr76d2mmz9uch55uxqkk2nzc42",
+      "liquidity_token": "terra1rxsqmtax455x5628dzhjtflcs0grpxar6hcgvl"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1v7vp6ywlymprx9mk7ngm4uf0xgrz2ektg5wd6z"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1awhdnu3pug33yr86gfu8kmkw4kn4cn720gkc3d",
+      "liquidity_token": "terra1gtkh07x4puthw7tufyn4lnwyp625djczf4rvvq"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vlqeghv5mt5udh96kt5zxlh2wkh8q4kewkr0dd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra14wt2rhghhtuyl07h4ls78hjuh5gk4nxj66u2tp",
+      "liquidity_token": "terra1vc96k8egcj6wejqjd9k2ng52qlnk4ncucaa2dh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vlrerpu78hdezzz8zzx34adpced73lmd0ujyqa"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1qkjrvyzncs8h2w6zyctm7etv743x0vl5syrc3r",
+      "liquidity_token": "terra1uxgl9umfun75qkv4gctl3fk4cqv02crsl5y57w"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1vl3khh0w2fydtd72ly03vjmlll4nr0ldcl9u4z"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1nvmffcs9l6qv7c9z0unkt69jk2qtadaqw7skp9",
+      "liquidity_token": "terra1yek22pthmx98yn0k3jdgu5t9tevd79c9z8l60l"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun"
+          }
+        }
+      ],
+      "contract_addr": "terra1c5swgtnuunpf75klq5uztynurazuwqf0mmmcyy",
+      "liquidity_token": "terra1l8jgxd9uv430rdt2u58h4h7kdfxsle4w6w2ecq"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1c0afrdc5253tkp5wt7rxhuj42xwyf2lcre0s7c",
+      "liquidity_token": "terra1jvewsf7922dm47wr872crumps7ktxd7srwcgte"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
+          }
+        }
+      ],
+      "contract_addr": "terra1hts7pmh590w6hd264pq6pm8ya0ck8qxsethpfp",
+      "liquidity_token": "terra1uwedwfrkjnxzf7q8t5wjj5fcymp3kjdsssjzjg"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r"
+          }
+        }
+      ],
+      "contract_addr": "terra1zgrz3dc3cpgk9qet8r7767yvpdpsuvlc6ymvee",
+      "liquidity_token": "terra1da5mtfzkz6cseukw2fc9th8n2vee7p0vpn9rvk"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1drsjzvzej4h4qlehcfwclxg4w5l3h5tuvd3jd8"
+          }
+        }
+      ],
+      "contract_addr": "terra132qjgv0evru0em6v2rcwakgxzafjhwfz7fc7hh",
+      "liquidity_token": "terra1495vu7s83d8kyqk4lzawajqt5d27pjfd8ym398"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1dyptd3795l57lencr2eltut973kum8wgu36f7p"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1v0lwlpagxy4mpyd4j9xg37tq3nz4wrrgz98e5q",
+      "liquidity_token": "terra1hdnfxxn7j84t4jwjxsegd9qmcksfa8zjldc37l"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1dy9kmlm4anr92e42mrkjwzyvfqwz66un00rwr5"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1e59utusv5rspqsu8t37h5w887d9rdykljedxw0",
+      "liquidity_token": "terra17fysmcl52xjrs8ldswhz7n6mt37r9cmpcguack"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1dy469h5zdej955zgn4dlewrqxw2nq2wdegq3y7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1dnzskpmnl0s9la8g4jczfgpzfq62kh766cg3pg",
+      "liquidity_token": "terra1qsem5279xw6ry5ntcffwh0ypnexhhz474j4yhm"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B"
+          }
+        }
+      ],
+      "contract_addr": "terra1hsyfna6jujxrfd86043w2tcydyvql7dks9v4zr",
+      "liquidity_token": "terra1gjz8xr2z92pffvzgp0khu569njf75jkhe6ta04"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ibc/EB2CED20AB0466F18BE49285E56B31306D4C60438A022EA995BA65D5E3CF7E09"
+          }
+        }
+      ],
+      "contract_addr": "terra140dcz7t06l4llh38u62wh8rcm0gus9dd93envl",
+      "liquidity_token": "terra13ynn6xnvm6pj9hgaw0ywkewr0nv33qgc0pt8dp"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ibc/EB2CED20AB0466F18BE49285E56B31306D4C60438A022EA995BA65D5E3CF7E09"
+          }
+        }
+      ],
+      "contract_addr": "terra1tq4mammgkqrxrmcfhwdz59mwvwf4qgy6rdrt46",
+      "liquidity_token": "terra1t6chem282fju8jhgnkrpcm5ltc3frxq93qsped"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ibc/FA0006F056DB6719B8C16C551FC392B62F5729978FC0B125AC9A432DBB2AA1A5"
+          }
+        }
+      ],
+      "contract_addr": "terra194j4rhezku4dmfz2vsnpzqv0actlg3xepg7l3t",
+      "liquidity_token": "terra1efsarez7elxhvgeulu4zgmtg6g9rm3smasgglg"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1d9ec4gm0c03p74d3qd95qvny2ptf0ge5twqpdk"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra17v05w2qmmxy864ltjtts0nzqlzw32gp6uynh0y",
+      "liquidity_token": "terra1wdmkqdhqmyv9csgwfdh8739fu65qpay7jj5vvh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1dxt75lk0m5g0wpucg0mz905akta99fjhuhafqa"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra17qag5rxkfraheygnsq0xy6y4a8ay0vrmm5cftm",
+      "liquidity_token": "terra1l58a2w22pv0fgukypvqt9fdmkn3ktd0jznexyl"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1d8h5yckrkgzneng72c8yskgdfd2s9870fuxnfy"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1elte83u4a6yrw90qmaeee58w94sy6yq7mrf8k0",
+      "liquidity_token": "terra1cdhk0p72gn7fyhkgj229ynzt5j8n6xlkuteeha"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1d8uw3zddfrexn06f80nz6hx2cd3f32a7p45agf"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1enwvvus429s4yxr0d5umud3k6eyhln6vn57v8z",
+      "liquidity_token": "terra1hp9saxd4mjfrmmzlzmkt9x9jk69vpu7vsh6lwf"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1dgwaqnzp9yt4w4g8l2kwxemrhlwqm50j7eehns"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1xghv9y36n9nfvqmlksj8seysd3fftfgud3zgm4",
+      "liquidity_token": "terra1cvwy6kx24fhpeq4gjuyp2ynwcsxu8gtvk3mde7"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1dd2qt59v86gwgzl2e6u3xexefvrkjmgd8mu638"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra14tzfka0vjjw8sttpkg0nqlrs5a078ngmqxjv5h",
+      "liquidity_token": "terra12nl2t220t5504dgaxl7yj68vfs39xky7zux2pa"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ddjp4wgu52cktzgzvahwkr4dcd95mxaqad2pmu"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1l649ch0y5nxnu5mrkefjfsgyyn5yj9pqjyfgc0",
+      "liquidity_token": "terra1k43ed8sql40cxd3mgaqujachuhhdrpzvuj7tvv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ddjp4wgu52cktzgzvahwkr4dcd95mxaqad2pmu"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
+          }
+        }
+      ],
+      "contract_addr": "terra1f2d4qd9wdwrwkksezst20u0dgk867vuf438pah",
+      "liquidity_token": "terra1g7a4hl64r0pmjmdrd3cwsy2cdg2st5x7xlc6m0"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1dwyd6vds479kv54f7kucevny97lge20c3s9w2k"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra17zp4dqu3d2sj9kq8uqnsvwy4ll66g7380uh03s",
+      "liquidity_token": "terra1kslvxkarlrneqddynteuwhd4uqy2w3a36h0ce5"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1dwvauhhpsmhwjf2x32uqeukg3zdgm89zy6004g"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra17mwfdz84uee5vsq28463vng93s9w9v08l2m83r",
+      "liquidity_token": "terra1z9xh489wp8wksdqh43wsmmyvm9qepdltq87aqy"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1dw6yapjv8k8anef2kg43hewg3g73wle22ncaje"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1nf6wl37jxthskggvesngsp7y50s0jchmur57v3",
+      "liquidity_token": "terra1um0scxtlme7nrtdk4dmccwxvaggpr43qc84vfr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1dszjh6392kc6avpztu4vdx8xl0qte4ntmue07r"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1zl89gw3t5ykhfxtut3marguhyff9fwupmnmhrl",
+      "liquidity_token": "terra1pq9m7syytshndh2sckgxyrh83wsm59w4gduvg8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1dssh7fk2gjjgf7yhcrd29repaz2gnxcs9yj9ay"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1gxyn0lewraduax9lgcqekpcxf0yx2cqtl9pq99",
+      "liquidity_token": "terra12zl9vnd4rt0xrgt4zylztjcm40u7fmfcf33vn0"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1d3pmqshpe6n5cs7d6mnffdun4tg0k05zfy99zh"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1edrk0fflh8ve8d0dn8hna46ftvu9mrruhzeunv",
+      "liquidity_token": "terra1xajvgkhmt8lqkna2f5t28jegsywwkgxvncl988"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1dj2cj02zak0nvwy3uj9r9dhhxhdwxnw6psse6p"
+          }
+        }
+      ],
+      "contract_addr": "terra180jp452au9sfwq4kuxtsd9q2wzjfu6v9ghrkax",
+      "liquidity_token": "terra1je3y5wnfm5v884j3vdegcc8045kje39g6aflce"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1djd0hmv2hq8s0g9hs53s7gmc2phgg33kqq4uul"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ryajnmy7npuzq3de9yt9c7x8ac2awdtf8ekaw8",
+      "liquidity_token": "terra149zg8aesny2xasfkc4wd6z8agewjfq5uve3pfe"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
+          }
+        }
+      ],
+      "contract_addr": "terra14fyt2g3umeatsr4j4g2rs8ca0jceu3k0mcs7ry",
+      "liquidity_token": "terra16auz7uhnuxrj2dzrynz2elthx5zpps5gs6tyln"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur"
+          }
+        }
+      ],
+      "contract_addr": "terra1afslx9uqz7gw348kae05drt39uu2nxnrhlgupu",
+      "liquidity_token": "terra16nsgdnjwx6m48sua57ahh50a0vkf8hj4vpark6"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1nagqpmyw55yjphea4rhntlfv87ugmeaj8ym756"
+          }
+        }
+      ],
+      "contract_addr": "terra16rzrqaa3srgffadx3al0cjf9s6au0dy6ertxtk",
+      "liquidity_token": "terra1y798nnrh3qkhyswfl82m9emg5lffxhj82vxyfd"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
+          }
+        }
+      ],
+      "contract_addr": "terra1t33pflkepsmky9smma25ne05ghre3zk5wgz9u6",
+      "liquidity_token": "terra1njdw0fc5m52ucg777vc83ckvh2kpy6hwlucsxc"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
+          }
+        }
+      ],
+      "contract_addr": "terra10xafj6lu07e7at9nccfwgjyrqqjfnsp8wp0f9q",
+      "liquidity_token": "terra104hduate30ak42e42k284v66spfjmg80584csq"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1dkhqqfc4gkrcs35xjndvea7fl3mur0uptzmaxr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1tz76786rwwnfra68jx3rhfnst3p6d3dscvuduj",
+      "liquidity_token": "terra120zjj4dze8wll9c0xtxsmds7zv26n0cam852kp"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ueur"
+          }
+        }
+      ],
+      "contract_addr": "terra1ysac4wfu87qgu0qkkz8yrh57wwgx2upytva3fx",
+      "liquidity_token": "terra197utwawuscdxxt6j38smj3cs8knzvlj9c4grr7"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1pdytx5xzs57t6qqdrnf9vn4ejxclpdn7eqs6kt",
+      "liquidity_token": "terra1wegnql6drjz35m68xjnfrz4w9tp35fhn5e40y4"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ag6fqvxz33nqg78830k5c27n32mmqlcrcgqejl",
+      "liquidity_token": "terra1tragr8vkyx52rzy9f8n42etl6la42zylhcfkwa"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1042wzrwg2uk6jqxjm34ysqquyr9esdgm5qyswz"
+          }
+        }
+      ],
+      "contract_addr": "terra1urt608par6rkcancsjzm76472phptfwq397gpm",
+      "liquidity_token": "terra1pc6fvx7vzk220uj840kmkrnyjhjwxcrneuffnk"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1d6vy3aueuucu3sf5qkrccnq7v58uwegh9m9x74"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1xf3u2ka5tvtq23wqy9dk94zx3kyaqvttzfetvv",
+      "liquidity_token": "terra17a995wgrz7ch4qvk3s748tzs9u89a274yk8qh0"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1d633fx8wlpgqnns9j4xw66cq6ypdy4u8r0rr7j"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1dcq5sd3y34q4fjwgcja7uhw26xn5ylq33tk3gn",
+      "liquidity_token": "terra1ade4g64fk6jx3udjxrxz0lppqne3y2turx7cc7"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1dmkfkt5em3heh003hc9e0sqmplh2cp7vmuxv59"
+          }
+        }
+      ],
+      "contract_addr": "terra152t5qq55g5yfw73j4j2ksgcyyynsd6t2m4cdsv",
+      "liquidity_token": "terra1p6fhh4n9keyyhzq6stytvn0qs6etj8md6mwe72"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1duggxa56m97yfcat99ew27z3q4rnax4w4u8waw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra18paw08s6xkw23swl76w6njga2rq6kh80zch24h",
+      "liquidity_token": "terra1vwa9j8y76ew90v7ukh5slz9euj50dq22cs0qvs"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1dameg63csxum2hspscam9h6d33chnqa4wsn3sp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra12mehtwqlcypjlp6u6mf7k39c2esjd2w4fw4ke2",
+      "liquidity_token": "terra1xy8hnu2rdzl4agj2qraw022z2xy3u6a5ldd4cc"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1daa3rrcq6nk9vh3ecg08x7rmkx3h6egsfex3ze"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1pfdfzk3qs55lwtd8l00da7cext07ufpn9fe2c7",
+      "liquidity_token": "terra10skty5urn3fzfkwg3f93z2f56xm52gufh2u76l"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1wzxpydn6z4z0us0wpx3n96gcs5p9qqavhw5sqs"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1c535v3f7fz8a94wu2cev2p9wvzfv7x35uv7tk6",
+      "liquidity_token": "terra1xup47v2ypdhk4lpmjw68k8hlt9s2ejjg4pv83j"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1wz8w0susqsraw2smttuymzkgr3p8tgkntqhcre"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1znka2za38gsj3p8u8etlfejqz4prf3snz36tnr",
+      "liquidity_token": "terra1q7vnlkn4gqgfqucjp8hadz6nzpma759qvjttsx"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1wrqm3jzyustdme0vz4t2n8jefz9y6wkl3g39gg"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra17z6vpqp4dxymzn0ggsattp6nurnz4m0ggrs8re",
+      "liquidity_token": "terra10vw298ls3ddp86qzyrt32j7q9x476k3c2mpfq0"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1w94fk75p0qeas276kfvy0m0zhnwgcy49c7vu77"
+          }
+        }
+      ],
+      "contract_addr": "terra10h5gc8e59wtz3rxhrngjrk3m9lqvc9xs6hy5gq",
+      "liquidity_token": "terra1mmjzshcvdhtalmtugqalam7l9vk507ncmpu3q2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1wx4h5qzvgp90ez53fgqr2s9t4rqzzjc03cjxr4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1wt43khwmzaeyxm77jnq47hyurrehzczyzxxds8",
+      "liquidity_token": "terra1e0dkhp72ted6rcz2ptnggnvtfea2hw4r2luc5n"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1rxn03zjqscvv770h0ede4v4649y62zlr0lxlx8",
+      "liquidity_token": "terra1etsh6y54ew6jcud4yhuu8awfdcz4j6jev6ej3u"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1dgqs3aa66l24natsgslvwwkj3henn4c9uesfz9",
+      "liquidity_token": "terra147g65flk0wtqej7k87ggc53ftwu74w3l9vj6ln"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1wfau60yqgdtrqay0cdtcp5rre3l50khacyyhhz"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1jxzxyjf2cvl7d88un4pp9dak8tljvxhfpgrqh7",
+      "liquidity_token": "terra1qjlakmnnswdzmssfzurpdg48ygu5cnw4lg9h80"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra1r8k9pea8wmt93l703azhs82kpjva0cpq8tq5at",
+      "liquidity_token": "terra1c64zl49ukr62zdzdggn36luym9edyys63xkywn"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1305xtjl5qtlpdlp8gg0k8u4yl05hj7qvyffvd4",
+      "liquidity_token": "terra14nhfccre389ypnmfr5s462gyhe05naqzwumss0"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1wdz268njqhhpy30qcd6zxmvtu5y0xr06cnkdqq"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra13eclwgxxns9v0m6nxveug7m54v49fsfx9fn88d",
+      "liquidity_token": "terra1jmzlups5p4upfx995j824vyngnahsx5tjpk3m7"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1wdc6xjyng08qwssthzvd5u8a4z58r8jxxn3j5t"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ukrw"
+          }
+        }
+      ],
+      "contract_addr": "terra1cc2w6lgzxarvawywfr7v4q7nq30tfvnfs62u54",
+      "liquidity_token": "terra1zy5sjsw4aswykccwtvkaq27s2eedspvakut7gw"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1wwpxtgrrfn0jxq8f0hlrzngx8m28r8kd5umaq8"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1pk77hewqerplsemc7wu9h78zwxs7cktfejdq5s",
+      "liquidity_token": "terra1ukk0exsl5cejgnsn4jrdju83wrpdcwg0thfzpm"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1w0p5zre38ecdy3ez8efd5h9fvgum5s206xknrg"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra12jl0hnmgrs9j0tv8u7pfqdey9nukmmk7vehgkz",
+      "liquidity_token": "terra1tq025m6ms5jz6hwhjp9akt420mhe8t3evu0rc4"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1w0p5zre38ecdy3ez8efd5h9fvgum5s206xknrg"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra16w76qmlwdevxvt9xnfafmczrjyar6rh5rtsyhw",
+      "liquidity_token": "terra122tkw2svjgx50027hlf52xqca94sq6s4mkk9d8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1w0p5zre38ecdy3ez8efd5h9fvgum5s206xknrg"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
+          }
+        }
+      ],
+      "contract_addr": "terra1gkdudgg2a5wt70cneyx5rtehjls4dvhhcmlptv",
+      "liquidity_token": "terra14d33ndaanjc802ural7uq8ck3n6smsy2e4r0rt"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1w5pzereyvecexd9hsmlsakgnpjnlw56fgrha4s"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1vu0hrz47per5rgq3mqjw272z3wgvk2x2qudvcp",
+      "liquidity_token": "terra1v09eme9k7zfqjm8a5yf3wrc5t66qqfvm50x2ks"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10722f40cxl8tkxjk7f88uj0ehkcw6lu2j504f0"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ubluna"
+          }
+        }
+      ],
+      "contract_addr": "terra1z7w93yyhzl0vf6cxvt0c65ta2q48akft53uj3k",
+      "liquidity_token": "terra1naap0c8xly4fh5aq7vhayqrrj6pmt826r0uukn"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uchf"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1v25n4wuld4zyuglmurx32tru56qtk5hxqe4vu3",
+      "liquidity_token": "terra1sr3r222uaw80q0rnu04atj2hxtak3kwcgkvlj0"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra130fhr9jz0nylzhdvuwcpp3hne2s5qlft6hfzgv"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uchf"
+          }
+        }
+      ],
+      "contract_addr": "terra1sgpvnwxmd9gmhhxzw03t7qftu00x35994denrm",
+      "liquidity_token": "terra18vqxp8zhpxclchwxwwr8ze2ey8qsljm3fwkhnr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uchf"
+          }
+        }
+      ],
+      "contract_addr": "terra14lg4pfn3s5p4zcmujnppvpr09n5a7583cz4czd",
+      "liquidity_token": "terra15m3ffdydxu4jz2d45q2jwhfmwc9vuk85syqsqa"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uchf"
+          }
+        }
+      ],
+      "contract_addr": "terra17ef74ttzva3fg7kc29w8na3nut8ugcdmxyycw2",
+      "liquidity_token": "terra1zq56xrvegmuwlvcmmhatt37gsx6df2n3j759t7"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1cdg2m5swqzatvzuvseef9xcxpwqylx2h983hm4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uchf"
+          }
+        }
+      ],
+      "contract_addr": "terra1tzfcwlfyf8608y6m6xhelhckd97hquqpu3rp7j",
+      "liquidity_token": "terra1ywx5h3cz6w4h3z9q9vg874y5f58gnkkuajfejj"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mt2ytlrxhvd5c4d4fshxxs3zcus3fkdmuv4mk2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uchf"
+          }
+        }
+      ],
+      "contract_addr": "terra1pcgx4257v8lskc9dul37searsf8uh8zyrj077x",
+      "liquidity_token": "terra12jcvk4ltvdygacp2k56vnre42cjwr60jmv77py"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mjhrlgwv8dnvc7mp0cynfxna947hxnm5m4tp6u"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uchf"
+          }
+        }
+      ],
+      "contract_addr": "terra10xf7yakydjc5q4uye6zuuux8d3hxet2wpfk4se",
+      "liquidity_token": "terra1xm9elzdgt0m8hpvy7kj3dwh3xd5udpplw84wm5"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uchf"
+          }
+        }
+      ],
+      "contract_addr": "terra14czsfcd6j4z8ffyekkgsr4zkpw8tdnec0v9jz5",
+      "liquidity_token": "terra1aukvhzg6q7357zzh5ydyzjc6y3ye6meg9qn2yt"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17n223dxpkypc5c48la7aqjvverczg82ga3cr93"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uchf"
+          }
+        }
+      ],
+      "contract_addr": "terra1m6kxrr0uvyy7as6fu2p65p4kgzg9rww9j9yhj9",
+      "liquidity_token": "terra1293yfuq5y40exg47kutfaelhknaegq6rk02djj"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1lrdzs5tgllwqgawtq2emuzn7snpxq87fzzl44y"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uchf"
+          }
+        }
+      ],
+      "contract_addr": "terra1p39xsp5j3e6e9703gguen049pkf4p52rmwf2vm",
+      "liquidity_token": "terra1w8m7qm67t90mzykvgtn72ug7lm9cac8kaggmga"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1lladdxhn49jz0hrvwgalu4a548txh94mcec595"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uchf"
+          }
+        }
+      ],
+      "contract_addr": "terra1mlz0yv4j8rw6saz5v7fq35m0qtacag8qj4hr83",
+      "liquidity_token": "terra1shgxcgjrr8wvnjzryzmkyvkc5rptsyc0thd75u"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "ueur"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1nfe80fnw2d0wax64ag7j95evqglqelhkh78l6t",
+      "liquidity_token": "terra105j7u0yn7gjx6sdnahd35a6n6f2hm6y6saqz07"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra100yeqvww74h4yaejj6h733thgcafdaukjtw397"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ueur"
+          }
+        }
+      ],
+      "contract_addr": "terra1c4ddm3ds2zwun37r7ldek908ypkxxpkvkcat5f",
+      "liquidity_token": "terra1ce3ac6jqm396r4qtsgu5m37qxrk44q6n3ht25g"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ueur"
+          }
+        }
+      ],
+      "contract_addr": "terra1p2462m98je6pk3n03fwrnmngkm05mcr9pn6cmt",
+      "liquidity_token": "terra198pmh4mhd42ltqlcntja99fzg4psw7en4w3z7l"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ueur"
+          }
+        }
+      ],
+      "contract_addr": "terra1zrsuu42fnz2zaj0hgl8s9fzz78wgzau3464luh",
+      "liquidity_token": "terra1qt8fh9k45hjk8n93fxa2lc6wxfpcmgve38507s"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ueur"
+          }
+        }
+      ],
+      "contract_addr": "terra1lullqskr4jqh6fweuh9ret8k4f9ppy9nf9awtx",
+      "liquidity_token": "terra1tdsuw7ruwahf9hffnzudvppz23ak2e3m9qm8ef"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ueur"
+          }
+        }
+      ],
+      "contract_addr": "terra1wwyh5grgm8h7y2k0jy0n6h8em3su0cverprwgm",
+      "liquidity_token": "terra10erqkxp8nvhn3uv0lfpwyhpjh8872a2exudqkw"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mt2ytlrxhvd5c4d4fshxxs3zcus3fkdmuv4mk2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ueur"
+          }
+        }
+      ],
+      "contract_addr": "terra1e3d9xx54vc4fhepvgqhrwt7m97zftaxet2zayz",
+      "liquidity_token": "terra1qchhau7xaa5dtl6mvfftk5qh32qytt9pk9u0c9"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ueur"
+          }
+        }
+      ],
+      "contract_addr": "terra12ch7qqv9nulaak6wey00nlm8mfj6cmuhkgwayw",
+      "liquidity_token": "terra1tp8csj5nsx4m5t4hdn4ff5u8vw96j4wpvz2emv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ueur"
+          }
+        }
+      ],
+      "contract_addr": "terra1nr2hvucfvtnzxm39022jal53wker54thdkll4r",
+      "liquidity_token": "terra1e6dy7amgryx5xycq67wv2dxn6072kc9d90uyc9"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ugbp"
+          }
+        }
+      ],
+      "contract_addr": "terra1y0z6ulatz6puwdrjk3lnyltc2vg9rvgwyztrg3",
+      "liquidity_token": "terra1dwr0kh0gpv0xmk0u57m8j7clg3s0zq9d27aawt"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ugbp"
+          }
+        }
+      ],
+      "contract_addr": "terra1dtsjzg6g5zkqsfwrw0uxlyl6e6u4kna0xzk0q7",
+      "liquidity_token": "terra1vmheszf3h84h4s08ru6s9p9f5t692s08vwvppr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ugbp"
+          }
+        }
+      ],
+      "contract_addr": "terra1gkx2ft0568avqalllpj0d29gxkfq6spk967vzu",
+      "liquidity_token": "terra1zppeatj9dmjecgl2dqkqw8fjwrcmdzdf0kh7tc"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ugbp"
+          }
+        }
+      ],
+      "contract_addr": "terra1ggqhles03a4zcxp470s0nwctm9n57ggae0vmfj",
+      "liquidity_token": "terra1hu7f7es3y2y20a55h7v3fe460nhc368wnptx35"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1w45ywafn2srq3q6svsam067uh8l2smlu7ljzv4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1enhh46s0ry3mnj6zx0rd2jjr0pyuspmueywaxl",
+      "liquidity_token": "terra1hwdhxcm974vmlva2u9cd272ck5aegna8uh9t7n"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "ukrw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra1zw0kfxrxgrs5l087mjm79hcmj3y8z6tljuhpmc",
+      "liquidity_token": "terra12dnl585uxzddjw9hw4ca694f054shgpg93cg90"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1nzvqd5mr0jn58cvam9j06k9kry4myu0vp7a9ug"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ukrw"
+          }
+        }
+      ],
+      "contract_addr": "terra1k9ndjyjxmyqe3kk7sq92p42kz8ptrtz9wuyq6n",
+      "liquidity_token": "terra10jmlz5uwz6w5hks8y9tretjjk4f8ad2me44lve"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra153qrdszuq65avs9flpeve43e46ypvt4clj6p4p"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ukrw"
+          }
+        }
+      ],
+      "contract_addr": "terra1l774jntnhr80wsj758fr9hlj49t8j5qf0dxhsg",
+      "liquidity_token": "terra1knrlem7cg0ywg5hldmghlj8eqh0f8lw2fhc599"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hwcnalcf35p48lvj3wt7tztkzh5szmpnxwyvdc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ukrw"
+          }
+        }
+      ],
+      "contract_addr": "terra150scqwurj3m6d5n0yt82zer4w8vsdf6hzl6fcc",
+      "liquidity_token": "terra12ndzg4g6k6q48hasdrrk7rul428npl88ljugtf"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1c2mghp27ysrmmw0na4cvvsmn5s4n27hq4hhfqd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ukrw"
+          }
+        }
+      ],
+      "contract_addr": "terra1u522uyxu6t9lku7gawf6k8evmrlqkjazgj4yk8",
+      "liquidity_token": "terra1wg3dhzz6m5q3dm738u6sxzxhld60l0chgvpele"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1aegvmfgdl4dclgpwtajll6382tcc7r0saa2eek"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "ukrw"
+          }
+        }
+      ],
+      "contract_addr": "terra1kcdknzuz8q5zjeyzyy30ykfpf3xs4dzxh57vgw",
+      "liquidity_token": "terra1t0mgl6lns0ff6wva27zjwqfpqrjdzw550ed652"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "umnt"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra1sndgzq62wp23mv20ndr4sxg6k8xcsudsy87uph",
+      "liquidity_token": "terra1xqeym28j9xgv0p93pwwt6qcxf9tdvf9ztfxf0w"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "usdr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra1vs2vuks65rq7xj78mwtvn7vvnm2gn7adjlr002",
+      "liquidity_token": "terra1mljg7dvzknqh3gc62emagf7hwxxg8efemennp8"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra1tndcaqxkpc5ce9qee5ggqf430mr2z3pefe5wj6",
+      "liquidity_token": "terra17dkr9rnmtmu7x4azrpupukvur2crnptyfvsrvr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra102cjx95xvww7cl9l6usxltk75ww3mpxtyw4lpm"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra1lp6exls2fpz3lv9yc7mtmc6r070zy4lg3lse6u",
+      "liquidity_token": "terra1uqlv6yqf3qqnftrlz4xak33hlfhkc80eucz4fz"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1skjr69exm6v8zellgjpaa2emhwutrk5a6dz7dd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra134xk6kqtwzw46qchkjsg9dwvufacmnulex2xwr",
+      "liquidity_token": "terra1qvuhgne7qp9gre8zmfrea6ekjgmda8r4hsf9ch"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13zx49nk8wjavedjzu8xkk95r3t0ta43c9ptul7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra12hxugtqvmqay7pzfnxa58t2p5ydcdfcsapkxh9",
+      "liquidity_token": "terra1drv4ddxm06t60yykvsh2jwd5awg80rj4ah820x"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13zs7w76g0u4qgagcen6vq92wxuvgfucr3dy4tm"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra1hfm049mt76s4kgsdrz7x0au4um4spyvyxe39m3",
+      "liquidity_token": "terra1rvsp3qg4k2vyd432xj9qzxx2p9hs2zzn5u43qg"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra1ejyqwcemr5kda5pxwz27t2ja784j3d0nj0v6lh",
+      "liquidity_token": "terra18cul84v9tt4nmxmmyxm2z74vpgjmrj6py73pus"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra1kh2g4fnhvqtnwwpqa84eywn72ve9vdkp5chhlx",
+      "liquidity_token": "terra1c5khguw3ensqawepuxh7vdzfpxa9ulwauhm0r5"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kn85pdmrhhk2upjj8hf97lx3w3jg6gyzasyksp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra1kf6ctpmz72mta3h2y68jyg2mlnxktaudsjcxdm",
+      "liquidity_token": "terra1cpttgtdegngfq5euh3nzcacplukxv3vr08u6t2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra1jxazgm67et0ce260kvrpfv50acuushpjsz2y0p",
+      "liquidity_token": "terra1nuy34nwnsh53ygpc4xprlj263cztw7vc99leh2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1677xekxjqc4f3jqut8yr6p29e8h5zfay37et58"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra1xe69w9cuwz4s8e6nsxsf439pr2jyuhjj24s0ch",
+      "liquidity_token": "terra1dypf4pfqw8a8whlkzhgrzew68f00z50r3hcd63"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra170hht9lwe50ugfhnruzjaezpj29l7nvw3l6725",
+      "liquidity_token": "terra1wdfhtdvsvjazrjnd37uyfzg45j2e0v32vz3ez7"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1u553zk43jd4rwzc53qrdrq4jc2p8rextyq09dj"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra1aduehngz4gzd68k8v474yaejfh7thf7cx8ml93",
+      "liquidity_token": "terra125am36fdtwds7elfm8yc8l3sg4qe3m0gv24snl"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1aa9kg8crxjq86ts54d4un6ku5skec9e98t6tau"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra1qgksgy6g76jx9732u8dpdy7epqgwtyy0rwj53n",
+      "liquidity_token": "terra1n45t7tamwtrnr48f43pcq8krul8yf4kap8xfcq"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1aa7upykmmqqc63l924l5qfap8mrmx5rfdm0v55"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra1xtm4yzrd3a7k6pzqjnk0kag0gea7w0rkkzmqg3",
+      "liquidity_token": "terra1wd57pf6alluruy72ctklzsl822eey2hvdsma8l"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra1zrzy688j8g6446jzd88vzjzqtywh6xavww92hy",
+      "liquidity_token": "terra1halhfnaul7c0u9t5aywj430jnlu2hgauftdvdq"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17wgmccdu57lx09yzhnnev39srqj7msg9ky2j76"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra15g3ecsr7xmz8q9uhtc0r340uj9eut4pg3umc9w",
+      "liquidity_token": "terra1d5j958a4vrfmv20gddyp0gz0f6yx0kpd702qke"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1l0zqxdgs5h6tfdsvhm34mvwrevyt5cuxj6ewzz"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uluna"
+          }
+        }
+      ],
+      "contract_addr": "terra1unvncye5u9qeme7amjf8snd889hm9mp93w4m9z",
+      "liquidity_token": "terra1s9gjv7083uvz0l90hdq2mq5d9j8je6w9ttax65"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra170r0wm50x5eh47zkvlrjkxhajp4g7wrmgsz523"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "upepe"
+          }
+        }
+      ],
+      "contract_addr": "terra1nhsam29a0cnxv0sd7tk8s5x676wq9rar8vpqwn",
+      "liquidity_token": "terra1xgn0ffavkylmh0rh2upgapj0sa9j9apray0eu0"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra100yeqvww74h4yaejj6h733thgcafdaukjtw397"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1m97h5kfh9gf8d42vuvhsq7es4t8y6s6dte8kz5",
+      "liquidity_token": "terra1un3hm3atn9kw5eavtsp84awhhjgjn4crr639y9"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1042wzrwg2uk6jqxjm34ysqquyr9esdgm5qyswz"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1j8cg2ncvtkfm00lvhsaa80rckq7cerhlvs9r5s",
+      "liquidity_token": "terra1q6ktjyy3mpk4edjz5lq3wphu860sqp2rkhchkt"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra17rduyemsyel8jl5pvyh7j33ee78606zqzkzh8l",
+      "liquidity_token": "terra1m7q2pxeq8fkw6xjsx7msj0gvnukrr35fthwhyh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15k5r9r8dl8r7xlr29pry8a9w7sghehcnv5mgp6"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1rvnzun0xww86xnhu88prga8qt2n2trkjm72s4m",
+      "liquidity_token": "terra140u2w6fe5fdvlf24rrmxw54pevvc5spdmkept4"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1sdmk3k5ajmnk5zdfujmr8q3yfvlp067h8syq5l",
+      "liquidity_token": "terra1nd7mj26z7wxpatnsy7qxms2lzpswv8y79zkyr7"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1l6s778y6gljerp0epa8wwmj7dxtlm7qfrmk8h7",
+      "liquidity_token": "terra1070nrsj5mf8qhess7f3vtylcmryhzpn9xqr577"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1v2yed2jlgunnh4u2xejd7c30ys7r33fheea7n4",
+      "liquidity_token": "terra1jv3g5g7sew53wzgu3ngn4e3ljdzcgsuzmhjsg9"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra13x30y5swfdjw4hhwpur83gljsf50s4afmmfrj4",
+      "liquidity_token": "terra1rkqdu7n85zqhgg78ktgv3rj5zvw6vp7m0dkx4y"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hj8de24c3yqvcsv9r8chr03fzwsak3hgd8gv3m"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1ryaxs8ppv0pk7tzfvqsglvy5jvfhql8jla7e4y",
+      "liquidity_token": "terra1fqa8d6tqpgqczws5wd3fhnux8cfv0kk4ng2fpr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ez46kxtulsdv07538fh5ra5xj8l68mu8eg24vr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1et8gmg0khfmv04vznevg5fx9ngucauh6hg3dm3",
+      "liquidity_token": "terra14xvjk7nq8ee6ks4nzgaeexwmc2jgv9dxv73d4s"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mt2ytlrxhvd5c4d4fshxxs3zcus3fkdmuv4mk2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1rsuhf9cfvrfcj5h2h28ad72hhqgxxqyg2pf74y",
+      "liquidity_token": "terra1ce5l6em2gc58lu0ltxq5xsn4d9u3nj49qdntjv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1r3djf4znn0vknjhdmlyg89hd8955v3vhr7jj5h",
+      "liquidity_token": "terra1jc72rjdtrlrj60my50skekxufrqlj6m2w754qt"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1u2k0nkenw0p25ljsr4ksh7rxm65y466vkdewwj"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1py6jq9p9qjjsqfg3sfj3stkpggyxl0sy5a006s",
+      "liquidity_token": "terra186hhp3gfmqf2353pekrcmdpajfveu56j0ej7ft"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "usek"
+          }
+        }
+      ],
+      "contract_addr": "terra1fykaggpacrhy6rjh2u7vs3ec8p9u3l7ynf6gy8",
+      "liquidity_token": "terra12apekfpt3pzjrcwz7rqjswqr0nsrezjkvlzvzm"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra19z6n7l67rkg6y7vggwr3jh889t9vg6yn2jdl9n",
+      "liquidity_token": "terra1p7zqell9644a5dn5347dz4gy7uzlfckp3l9jru"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1wky9xanuqfjjy4kxt8xa2pcrf7x6lf0zlwenq0"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1gv6t0xkxdr096gkad4kksxr0kjl4rxuf583rgr",
+      "liquidity_token": "terra13u54znnd3m8xx6cmujxk6z8mgmr8mzmcjvkc0a"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1whwxszdwu6m4pup0glpfn7qhwmnh6a49mrsv2h"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1s2tkg3l4h4hrlsq6dnatcfhv97lyutpmxw0uk4",
+      "liquidity_token": "terra1hfad2shn4h26g75t66yjasyg3qh84xlkp5g838"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1wctr29t5gul8qq6qvk6lue2lucymuptvcn9avl"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1x97r54x6kqgm7e296vk0rnlzaryjvj82ad3aj9",
+      "liquidity_token": "terra133t9ekfdgqyfxpmd2ztaz64nl3pdvaep9su8n9"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1we9tgz73r6q3nqxwre5375l0nxh0s7ry47s6j8"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra19kagxwyn0hj9nyjwzex5w5w609zggp52a58d22",
+      "liquidity_token": "terra1w34xlv8euhjfffp3mu98qtc9umcwy79jw7pfxe"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1w7zgkcyt7y4zpct9dw8mw362ywvdlydnum2awa"
+          }
+        }
+      ],
+      "contract_addr": "terra1afdz4l9vsqddwmjqxmel99atu4rwscpfjm4yfp",
+      "liquidity_token": "terra1stfeev27wdf7er2uja34gsmrv58yv397dlxmyn"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1w724lm9qt5q8rz9n0kqlfglkulz7z98yjvxzn8"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra19t84ksmw2nzvngvmy5078tgku7mylp5engu3dv",
+      "liquidity_token": "terra1urmsz92gxy9fwzgy7dycjc0au3x7x95ntwamsr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1wlwkuyv9g7d320dm5cqg6wsygplmt8tjjglc6w"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra16qj6hfx9t2st567eg0hzfd0vq3dtvvc8y0knxj",
+      "liquidity_token": "terra179nsfzyw6gpd4aqjxk644y662geq0rdyt90cay"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1wlhgvtult73t5vpeng4sw9qmsq5jlujfm98gg2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1nksjldc9ze8ql6e93fms7d2y6t79h8qzv0q4yf",
+      "liquidity_token": "terra1xyzz6yvtvndqx4hp78vuvnzwt82xraw8xd5y6v"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10qjtgmpsnx7kn53nxmw2mfx626g8y4xaw04pd8"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra12eazlqlhzxhmp546vvhd0ukqwqfjzv55es8fgc",
+      "liquidity_token": "terra1wwaj9xx6apx5d3pta8rss4tn6lzgdhavs6wgnu"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10pvdslu4j8x6rqm2uuvh7dwd3rtaw9qq37g7v7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra153xclqwcvxch99mclac5fxuu4cmeu7w7mamghu",
+      "liquidity_token": "terra1ze0k9tty5hrn0t0m2dt4j0sde7vgjsrttczt7g"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10rv8jte682eec8s3fyd522hhq577cl75zghx83"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra18k700765d9kyglezc07n64wnkdcfzf9d6juccz",
+      "liquidity_token": "terra1l6nvej775vwnlmf84gzv5utyjw6rh0unyyc2y0"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10ypru3yma98ukk3anr5cjv02yq839pcvqc476k"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1kd38g9rmfvklwyrszpe43dddhvl8zdgeya6ms4",
+      "liquidity_token": "terra1ek3f48k9xje7zr6ytfdm2p9xe5qkx959kgrle3"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10yycj46tjfnfhkk5d6er49gvcn28jpqk0spthr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1r66l8vkzyhduuq7dfc8nm6p9wlwtnclve4wpxl",
+      "liquidity_token": "terra10zlafqxy3zyfx2wh35mxh8xepp6fz3f3yl9e8a"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10ynpvp8trmlkf6n69qx0kp9qjs54d8wsh2pddc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1sc02s2q53678ase0uh5e02x95dv6knkkgf6xwx",
+      "liquidity_token": "terra1u3zraaq8n0t7550mzlq9jv68pzu0nphx0rrxau"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra109vclyh90fkj77ruk299pkk460sjm54vs9x6et"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra156wnmhqelwxwcmkfcn0j5fehj59ktjv6w4xca8",
+      "liquidity_token": "terra153pf6eyne720ev2nv7c3atxgrde9uu8l7h9e44"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra108fs4ahf6zzy7tqpvczg5yrfjpqw20kxc43pq5"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1vd20ymyajdvafp3726ft5wlndnlsqmyfr6pr20",
+      "liquidity_token": "terra1hgr37dvhd2r4mz0x5c2g60z0ggfhxy0a3lq4vd"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10gpgrr85u4g42uu6c3hkkxkggg2nw5kt95yc7x"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1dd7g5js5xqqkl2fse28hee38sdes7sv6f79pfd",
+      "liquidity_token": "terra1q94p9qjlykvzd2m0uv22r6uaj2k7gde0grzjcu"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10famrcyze8z9c84x5726aplefwuf4k2zqf3rxr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1qll0dwhllspv30xnekl2csr6k3ykygtqdzuxl8",
+      "liquidity_token": "terra1fgc9vy7hhzjgv90chemxgs0p5j5dfhkzsfexlt"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra102cjx95xvww7cl9l6usxltk75ww3mpxtyw4lpm"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1faaael2u6jp9wscfvwqu0376djt8t4rnjmn9p6",
+      "liquidity_token": "terra1twkxlsys3e02tw5kx8x4uw8xvhhv40ym3tsaky"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10t0rgfryqz5ds93z5tqed740nqh4ele9lm9fhq"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1hxekdhzzlqrytzvf7vl7jvz8tk36eldmaygdu7",
+      "liquidity_token": "terra1x32xraswsr08qg9dee6jkkjac4y2j3q557f8q8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10t5spcvn5m52fs4j5tnjerm6wzsn9vuqdsheje"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1uxwgfuyn57xqek4jgxajhd3270khgyusncarnv",
+      "liquidity_token": "terra1t28ggklvxuhvfgd78em98rhnddeu46vxjjgl82"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10thstrfuexp5nf9rnazzs433p7zeu9yxr322r9"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1eazr5t02gql7prqus2a8p6cc78y8vks04xc4za",
+      "liquidity_token": "terra1fwwxakw6ue3jt398uneyf8agnwyf2pys8dcjcz"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10vvl9llw4p7ca2zhmcdljk5el9fkpp9hg6qy53"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1uyq0vtcmzhz754z5rpv62u4skf7s4e7fuancwn",
+      "liquidity_token": "terra17wctee086rxqzng25jsm80u2mf5wx5lnyghuhw"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10vwyclaux26l47hj2dgnjw2pcsrt4y0ukfgp9u"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1fmp455y0fgee5dv68fxwfnylnpux6fv3th4m2f",
+      "liquidity_token": "terra156yh2j8krf0a6kjz2gkf9skkhefg9cdmvc2fpx"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra100yeqvww74h4yaejj6h733thgcafdaukjtw397"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1xj2w7w8mx6m2nueczgsxy2gnmujwejjeu2xf78",
+      "liquidity_token": "terra1n3gt4k3vth0uppk0urche6m3geu9eqcyujt88q"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10s8n4uqrtvtz5dw2yrufh58m5e04alx7mzwftc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra17cv4q8qvu2dgd7x9nwk4kcu4zkm8thmsc04fuy",
+      "liquidity_token": "terra1n0herpves8sxvxu6x6sur8qun72sczypk4k3ft"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra103ws85fnvy3j9vr3ss9va2zr26vepemqx2n88u"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1tezp3tstl052jltetzrmtnvf2k9lwev8f23xqt",
+      "liquidity_token": "terra1ykv0r4llzml3ngc8wxwag8dp83z80v72l2tnmk"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra103355s7hcypeuzyldvgyn3u0n2uspu3h6mm8cj"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1pkrlesjqxs8e4ymnvtdhdqrmvt6gnw7p5ywcwc",
+      "liquidity_token": "terra18s8nvdrftsfem3hagmtgxphwtkttt6hgpz7lk8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1037zmxv6f73e5mlq6hsyadlev0fj4q462llw3d"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ml720ts5kfg5s9hhsft74hy6clqsevsqkvu0du",
+      "liquidity_token": "terra1vkjgr2rsagh52jdcur4zgjyj7ag5xrfmyekne2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10jyyy0ylv34lafqv2mldcuxhk4qpdmnckgfls2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra105cnw8azykz23ec9gtm06prssq9aqxg8pchjq4",
+      "liquidity_token": "terra16n3xcufpvrgv5nnrjmcg3qnypuq30vutmq4l8k"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10jgqgc3vt34w79t4puharnzjxxv7s3fq8tmnkp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra15p4lwjtk9jkkvkz33pf5xelnrnqahac5ksj8cj",
+      "liquidity_token": "terra1wvglhgmnfyw0z8h9ucjyyye2cqds9trjws9u6t"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra105hjuy8z0j0w4m0frlaynrnu8smk8qrsk36mas"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1e9zck0ak5ufz94csu83p90xu37q22dhk22trh7",
+      "liquidity_token": "terra1qffrtdpnj9afjw30njnw84f5rfmkxv8c86246h"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10hr9gx9m9tq44xcxk2c5mzzlk7p22zd7x6esr7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1fhs5njpe2sy6acf7r3s8qh62mvs0dgs5wntdtu",
+      "liquidity_token": "terra1xapjctwprfuqpcte2h4mnpxtf7nh3jhurgv6sf"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra10h7ry7apm55h4ez502dqdv9gr53juu85nkd4aq"
+          }
+        }
+      ],
+      "contract_addr": "terra15kkctr4eug9txq7v6ks6026yd4zjkrm3mc0nkp",
+      "liquidity_token": "terra1ndlx5ndkknvmgj6s5ggmdlhjjsz0w6wrnwn5cf"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10c4zqj4f7ze4keuwvm6hk2wrdj9p8h07sp4fg5"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1cj2du5dmwr86u56u3xp6kx5u9ww7z2vcz2vrrr",
+      "liquidity_token": "terra1hffx97vzfuj5ysxtpzjpatf5utpaqces0dvm3y"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10ewuq49hkk438jhd7q79hfetqpkkt04tfm7rzc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra17hfwmsfq7xmecrlzaqgqqsymzr6jz4urcvd9sq",
+      "liquidity_token": "terra1enjwdma23v5f7rm5xc7zqq8rra00ggmr464nkf"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10en35kwlud79z2nljssvhp85ep5kx9k0ezzz8s"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1avv7dftyck6smyxl8k4juw4qkg8pef5stc7kmx",
+      "liquidity_token": "terra1xj8v6a4wajsjdc4r74a0285zuvst2rmkau5txl"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10aey3n8rwxup6l2x68fa7fwdurxnu9hwxf0k7f"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra17lvnk2k34us38zflqz4zze6zkn7vrktpeuszcy",
+      "liquidity_token": "terra16m0mus8nn6ye0j2qze5ffpl25z8mw0tjtk2dy7"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10aa5cyfu879fm88glc099sjg8unejcp46cv6hd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1juyxhxne0gm7nma4vrm3pz949lj3p5wg266x55",
+      "liquidity_token": "terra159je5qq2c45l4vl4j2uwpelyxvmf06nnqyyc3y"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra107pw6g56gfch98r3xw9gr3glcxvmmm8326rdg7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra102a44aeeq4x78pmv5kj79qxaq2ghtsk24gj6g7",
+      "liquidity_token": "terra1x6dwnqnr890whm0wtzz9td052s7008g2tg8ffp"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10722f40cxl8tkxjk7f88uj0ehkcw6lu2j504f0"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra15z794we063zfzxtvlxzetnq9cv7ftymglqh0g6",
+      "liquidity_token": "terra14jd23js53c4kk8rqxy6v6h7ju6cc8f9kf70v86"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10l407saphqe2tc35ejhzg7xyulqkeqccvvc6uw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1lskrhzzyxtm235j69ty3y4fk7mswczq5f93ntq",
+      "liquidity_token": "terra1tmfam6rhnv0r3u6ejrc7fdn5m25kulx9xsnzzj"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra10led4w62hglspyngk0ydxjsdvelvwthftevq0f"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1s0tfy4juc4pj4ke6mr9u68mnmgfapplhr52fr8",
+      "liquidity_token": "terra1aef680pzs5cm30655wdz664v8jgeqtw76ptmcg"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1sqagv65dlqj3hlg4fxrljlhfg5wulsp4nm58j7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1qrlz2dl224glxn7sqa56wpdx7dz6yn5jlxm02f",
+      "liquidity_token": "terra184waaggxgdg4nevql50lmpeyferkmal7f904eu"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1spe82hmc9j2y2vjl6urue78zhrn9r9xyydkyx4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1fpnmpty0r6fmyxnfzere7xd62cnjaumslzz7d9",
+      "liquidity_token": "terra1fwcdnx8flnyy4skav4fvurtmrh86ef9mkumgt6"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1spuk4t4lxsmgx8wqq0ltqrxagnrzwvk6lmf4t4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1mp2d8zjhtenah2rgv7p4g6zaxp3s44pqx9z5ek",
+      "liquidity_token": "terra1zjxyrnfgf93kw5uhamvnqxdfnczqhwsgpe0evv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1s9jnada32ld74gmng8ng5l3zfy9vk8kfds5828"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ctdwhvfkhrp8z8l78l85h0da6ywlmp2yjtws2e",
+      "liquidity_token": "terra1edy63xnmphdr47p97hw3h6fu72md3u952ra0hk"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1s8gu8mx2qcxpx9y90fxvdetpwq9mpyrapphw2u"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1pr6tmhnve5cawzauzyzw5uscz558gzmd3d6wps",
+      "liquidity_token": "terra1t4m40patyzxcm65fp2sz2p0f8yzkcdejrlz4wu"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1sf5tt6p6wnlhm0jqlflan8lw7pmv3f82sffsja"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1970uk99ys24x9xsck497709n4tzeaa5lgkw0ye",
+      "liquidity_token": "terra1d83udzk95gnk2np5wklqj3hxdq59r0ely8tdea"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1st4q82j2dhzwzqpyyr5yxuftejfn57k2d5q25p"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1c89cmylgqanns5vgp8280ehs0tskv3nn5lrhxk",
+      "liquidity_token": "terra16zsgh32hlpm5zehjdhqq3tfztw65jv08kvgayz"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1sdm7qux8u0qtfxa6ukuh3zgppazdxlhmmjks23"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1rcdumk59pxaem9my3frynyu3jgrkj9v4han9eh",
+      "liquidity_token": "terra1w3z2lk8skrdw7ar9vq2kf5jeam9ar0m257k843"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1s0y8aldsy3t6wtg5tpwe8xzq3lyet5e9grwmlz"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1wcs60r56r743ws6nxv3tn9pgz4xqv3x4lgeqkt",
+      "liquidity_token": "terra1drs4cetuf7hxry0xrh0vz79242f8clmtjpwhft"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1s0fnj6cz44e2j45293320wmwmjp5pmdkuuv878"
+          }
+        }
+      ],
+      "contract_addr": "terra18xk94xj3qyrv4laxy25hhvwggr8d4g5z6ynl3p",
+      "liquidity_token": "terra1na4sgkt5ft37s72l9hd6wsa7hdql0j75er0u7l"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ss460ny4hl5zew0tlvywnw38rsy2ql3n420lv2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ds7gy9gyf9e7rl8zmmtfjt2e2dm4d6p9szu8tq",
+      "liquidity_token": "terra1mqm4zudg8hyg3lyjh46vuqd77qf9lr2wznrgpe"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1sn208s2cmya87707w4r9hf36znv8ml8dcnhr2d"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1f9aln0c98j9w749szx958la7x25chdnz9hqx0v",
+      "liquidity_token": "terra18fafa8k888gyu3zza7dhcc77xvfzwplnqe909y"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1s5eczhe0h0jutf46re52x5z4r03c8hupacxmdr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1tn8ejzw8kpuc87nu42f6qeyen4c7qy35tl8t20",
+      "liquidity_token": "terra1y9kxxm97vu4ex3uy0rgdr5h2vt7aze5sqx7jyl"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1s56hsyhyvq4xxxvnz8qr0pnktm2dadsm4gkl45"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1klw8gs2ra6tvf0s86kvye26lcv3ztf885p9fwy",
+      "liquidity_token": "terra19uvpg6ppn5jqh85c72rw8ywnyr9ecalgfe20ek"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1s44vplvv5fphrrv4g68gx46xwrmvnqm9e0hazl"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra16v3cxjng86zd4hmahglj89k9gejh04nghnyavx",
+      "liquidity_token": "terra12sv6yvas2w2wrtjzly647h074tq8g48lxlqpaz"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1skjr69exm6v8zellgjpaa2emhwutrk5a6dz7dd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1rhsh5xxl52xkuj7qq9240hwmcyzq2gpyj9hl0x",
+      "liquidity_token": "terra1s6e449z6xz0vm0tx2h5p6drxwz9r2jvrcvcc62"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1smeev4u44zhv94cn4pyy9dtsshup53n9xefayx"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra14ma9cyp3xt9rj3jz6nmz8zteujuphuyssv7vvj",
+      "liquidity_token": "terra14nszv45yz78hm2n69rq69g5xa2l4cznak4aa4z"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1su29mtytdsev3ty2au5xlfrqrjcy696yeqwvcy"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1y03ldlhcscet96kflc0fefnfkvug92ly3xmgr2",
+      "liquidity_token": "terra19hvxtwdprvaadfldxhyc0demuyhhz26z86r54r"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1sussd2d7r3y5k6up6n6sxap3ee75gegxah96up"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra14zcs4sshhncym3ahuczw2rg7r70xhd9zl90mzt",
+      "liquidity_token": "terra15ua5xjmgyurtrltn9gp6r7cap79xdfjksxecms"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1sa0klf6nt77z3afqlx7nq30xrvr7hsfz5jsqmd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1qr8vxrmlsyune368pd9nmgfuqt7kdek7yy6kwx",
+      "liquidity_token": "terra1trdcl3lw5ca8ta7nfm5qh7w0mudfn6fdhl2qm6"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13zx49nk8wjavedjzu8xkk95r3t0ta43c9ptul7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1p44kn7l233p7gcj0v3mzury8k7cwf4zt6gsxs5",
+      "liquidity_token": "terra1khm4az2cjlzl76885x2n7re48l9ygckjuye0mt"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13zs7w76g0u4qgagcen6vq92wxuvgfucr3dy4tm"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra18nz2gztwduce3u40wuuafl8xj8e4s63nty75ym",
+      "liquidity_token": "terra10n0uq2w37h8q3fjmdyxml2z54scv9695ljhdth"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13zemc0wmem8lt0un0lya3qtg4cpf9jcdsgtvf3"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1uyd2jx409kdesatvpwrvzkuvfyhfa0es0r9s9g",
+      "liquidity_token": "terra1u47cpzrevxlld30cw6veflzj569k5ayyly4c59"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13zl9thu8cgpkvpsx8r652hvgw4p2v42sahz6t8"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1tetfz00c58t656cg2gtyyv23jwh34sd590ue33",
+      "liquidity_token": "terra1ysma0f8sw7254l8nnfylfl4nded9a8wj7mn8up"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13yf7ukapmeznh2uamd0342g0hy872my8shc74j"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1dagf0h7ux63pqak79m7rqsnm5yujga48sg37pv",
+      "liquidity_token": "terra1mf2f35qq37pkmq6e657ha0asc6tzxm8zwaxg6r"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13x03uqz06gkam3dq4dgx0tj89dpw3vs2nlftjq"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1dpp6zc305d4fux8j3sp2c2x3kaykha8enhl3ur",
+      "liquidity_token": "terra16e6c93s2ye74hnrw3h406zadl8r0sdayw05vxt"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13xujxcrc9dqft4p9a8ls0w3j0xnzm6y2uvve8n"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra19pg6d7rrndg4z4t0jhcd7z9nhl3p5ygqttxjll",
+      "liquidity_token": "terra1uwhf02zuaw7grj6gjs7pxt5vuwm79y87ct5p70"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra138zs0y4arp48v0vpzqa7r4ehxcy7sk3dpv606e"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1svqq5rsjpvsrt6g365wrrxz3xje0jnjljax42r",
+      "liquidity_token": "terra1pkgrrs3m3l8twfr76qpe4k0tccfeajkcrfhnpz"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra138d8ek2zl48pp3el4s25jxnxn8m9nl2n4y0glm"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1l0ldny298vsdln3gsd8xsfzln8yddgntuc3e4p",
+      "liquidity_token": "terra1g666d8h4hsqhw8s8axdrzeu6n7sul2w2zsgmn8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13gdkkedrnd48kel0fc8sr08usdfpdce9ku6qku"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1mtt2dpjah3mja54rg9exyexsdkw8u3pljdu34j",
+      "liquidity_token": "terra16ledesd9tn24fte454883p577qvr24hngmfefg"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra130fhr9jz0nylzhdvuwcpp3hne2s5qlft6hfzgv"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra15yyefja9as60nfn5dmyqt8tm3flddyvn3apf3s",
+      "liquidity_token": "terra1y4z7u7psjqyxu4uw5rwz8wmhwrpweay4t0le42"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13sg4qarsjual8ew8sr4nwtkv6ut4dd3378820r"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1qkf2kffhu3f6x4d34tu67eu2u8nkrqrn6w3a2n",
+      "liquidity_token": "terra1mspnuehp4h68f03t35lr0dzz8ajhzdq9jazjk8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra133q7a0uctlld9kru6put3hk99qvxm9qzmklu9f"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ka5d8934txtr2lhpdk40334k30t66hxyqswq37",
+      "liquidity_token": "terra13vxffk8n8a65lr9a24a7g28ls5hzkhcf3kzvtq"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra133j6tpq7gcrjjgvgj4r3fjwda0hegmmrazmwt0"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1dvwewun965qpex2k8hrpfpzt8t7qtq3ptwu6j3",
+      "liquidity_token": "terra1j7q92vh3nvm0srpm86lhte566guh64myzw007q"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur"
+          }
+        }
+      ],
+      "contract_addr": "terra1mv3tksqwfextmnejw8s7ada9qu3pwav098qfxu",
+      "liquidity_token": "terra1xgkkmc6luamzndndxtpg0520ajsnzzplcavq76"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13j3uuywz8q3tljmqxt6trcgcxy29dd5exrnhtq"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1vv088zvmzzjv5qgpu25ym9mlgcuxhksqxnrcp2",
+      "liquidity_token": "terra1svsdduee7kk6ghh7hz4c2rk8tkagfkzaplltx6"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13jkds0xx2hy2xrqwggzkt4navhremx2cjyl7aw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1v42wjhpntmq8nxjuqm6tttkx4q8zfrdd7ps3z7",
+      "liquidity_token": "terra1gcutnc7f30xz22v3652twfvmfmj6utqsfn8wlc"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1353an33z0u5dd0yajwjazfnyt4585q5085c5mg"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1yxfvmmy6ftelwk9ke2y7kmyxh7pkd0ev6d47e6",
+      "liquidity_token": "terra1mkmwqqzdhy6lvlxy3xel7m9uxsaq7n22rvs7t5"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13kr45ssru9cqhp2kaaan88wfaa7f2h3jfvuldp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1p7npd4c5f8vsr47ncvkm50qfkvddanwy4er5ls",
+      "liquidity_token": "terra1csfthprdmt6yw0n9kz3yuds5f36ng6zhwnzp3d"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13k03g6n38f4m90pchn5h3nmk55xrnzt5ksvsml"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1wysjqge8zc40e5g67vlaw0n2qu865pxxxv9sn3",
+      "liquidity_token": "terra1hlnp0hz3hg37la6s6ppwex3dudaawvn3e7tydg"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13k5m9dmcdm8y52j95tuppuz23lvjug6hrh7vjx"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1kljzhnu4edtc8f8xzxu223n03hj82k66xp6mfw",
+      "liquidity_token": "terra1caxrxg3n67egv4u0v6klt66nsz4y90sydlatzr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13km0x6rn7fj23ruqdqdqut7p7p7570xyjz35qe"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra14h9hukadz5qwm4jtxjrvnpnj52ynrnrcq6wjfq",
+      "liquidity_token": "terra1rhy9tsda27exlwlwkx62u4t2e6c0uq7469p0el"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13cjcf6r9q660qlq6yjmn50kyg4syz0x03z93xx"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1pj3nmuhpxsrlsgnkdrcwt3pyjln9j3dj95t8hr",
+      "liquidity_token": "terra1yzflljpl7j0nsj95qsj4jp65fqexzjvzkjwknv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13u7ddpvnxlephv6ltswy7c7hnq77agz5078l3y"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1kyrnvh3l0natnqsapzalahmp4t29dz3ylxkp3a",
+      "liquidity_token": "terra1qwyfe8zymqtnhcrt46yhtk290h9cdpynx3gg3m"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13awdgcx40tz5uygkgm79dytez3x87rpg4uhnvu"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra19fjaurx28dq4wgnf9fv3qg0lwldcln3jqafzm6",
+      "liquidity_token": "terra1h69kvcmg8jnq7ph2r45k6md4afkl96ugg73amc"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13awdw2dt45l958q274ukg0hvvmctghllv343lp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1l9l4slsr2tllds0r85nuem4fcmqrtjdp655pdt",
+      "liquidity_token": "terra12ncluxlmuwkhq492dkd8y6g8p9kzt50dvdxxtc"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra137qvfdvlkj9vfhrctz4rlkk7lmgql7xalqlwpw"
+          }
+        }
+      ],
+      "contract_addr": "terra1myn9wsgv02jny8jwhnxdf8lrfy6gvdnv2c3wk3",
+      "liquidity_token": "terra17tlyml4tq2hw922aq2dq4dhnjcu296mlkgrx6n"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra137drsu8gce5thf6jr5mxlfghw36rpljt3zj73v"
+          }
+        }
+      ],
+      "contract_addr": "terra108ukjf6ekezuc52t9keernlqxtmzpj4wf7rx0h",
+      "liquidity_token": "terra17smg3rl9vdpawwpe7ex4ea4xm6q038gp2chge5"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra137lajza996jtr3c338nz4vhkduynjesn2vz69p"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1vhac862xfcnpmqtsq76jz3nh0g2w4eg386lxay",
+      "liquidity_token": "terra1xy3w65zc99qrgfevrslspg94gjgmypvdseyjef"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13l9e6lelggxjzm7dxhgkfgqwutwr67y5qvc7mr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra16edju746kt6k44meljuql30scd6ml0ey0qwj8v",
+      "liquidity_token": "terra18kq50rff38rr6xt6etkkjvhv59msdst23pf9dv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1jp4r38w4j2qkxavjs9ypqv6mv833wdar3tywe2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1sh8rvvp8qgnncavkl3x55gqtd5mzy2yg90hcq9",
+      "liquidity_token": "terra1x0wp9lauy0nukzc5h3tqjcndcrgv7d7vyq9gp7"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1jz9plajrq6knks3vgv9px4ezwshzaxsr2xz7jn"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra17cfpltkk9ja3rcv3x9rwqzxdeqs9r67ga607lw",
+      "liquidity_token": "terra1udh2534z6lu609dtvlfp8y42w6tswvs5e9034d"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1jzvh42e8auxk63dg5vdp4lh0fct8vw8pn2s34d"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra18sdrrnm8v283m57pwr2d8m5hlxmwj2tgajj7nl",
+      "liquidity_token": "terra1ter57huylshhqmkjr0m8kkl773tk7f5p3dgjqv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1j9zvn74s7v2kylvv2xcg4p0s69pvejrw5qzv7j"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra10mwe766az3rz5u84h53z6u0hxq9jp6jx54z3jh",
+      "liquidity_token": "terra1tnj6gg7ntn9wht35uqxz5dpe6nw4fd92ukmhyl"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1jxypgnfa07j6w92wazzyskhreq2ey2a5crgt6z"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1xk72vswca7jkjg8cpl9dz0qvfadam3ms365lp7",
+      "liquidity_token": "terra1mxfnjfa0aj0prf4se7rwa45xlwcg8px97enu6u"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1jx4lmmke2srcvpjeereetc9hgegp4g5j0p9r2q"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra18raj59xx32kuz66sfg82kqta6q0aslfs3m8s4r",
+      "liquidity_token": "terra17mau5a2q453vf4e33ffaa4cvtn0twle5vm0zuf"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1j8nxezl70lfekdzaeanzyzn75htf4sz9vmwhu7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra16d99plysndjucurqz87d8p0my7z3kffuhehl30",
+      "liquidity_token": "terra10rnu02fhw7lg7eka8f2yw2wn9j7kn3mgqs860s"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1j874eyvev9pm7uxm0h9l82raswe3qwcug8wxuf"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1uqju4mlp0f000atx07xd49y3dlwe50e0d8d4xe",
+      "liquidity_token": "terra19t9e42yxukxuuqzyekccm5jpu3gek3nttdsz8f"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1jvg4ls8jz098g77t04u4hw2gg2c64w8t5g8jdz"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1jdzll6cwkmeeqjjkm4vfljmjx7aats8fyqmvda",
+      "liquidity_token": "terra1ujttg4pcvkjj9z8xazhzemv8kpexn3vexq4vpp"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1jvsfc3aedh7cyf3wd6vs7r5fmdsf4v6veh525e"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1m74nhtm9uj36jc3024y403h9cnh3uvthhpq6zq",
+      "liquidity_token": "terra1hfrwjf66e7ayc90p53t9h5qxcqthtg5ug4yejq"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1jwjweh50vrd2gg55y8cr50e32jwwc0vuhvdymh"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1sk902qkn05mm3j94eh6qz0rmj2rq4gfj363na0",
+      "liquidity_token": "terra10fh6hy5f9t8mn09qzrps889qtew2km3zs44q9x"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1jwnz2uet8f4yjqyntgsfrplp503wutt24n7srk"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra123ttrnasfv5htzt88phmm7v0r302z0lqh7l25t",
+      "liquidity_token": "terra1aeusm5e93ptz2twem0vpfy370c7d7vy2dp0vke"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1jw43a4x2jdftvk9ylfyuqhy9asam4ymjufme44"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra14cqsw04rl6lu5dghdzqz5984rjd3rryc2psu2d",
+      "liquidity_token": "terra1s9rf42yddzzxqr60l0a3dtf0qqkhq7cukql3p0"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1j0te9qwyxggd9xq7vhscnnek7yg7cv5gpgurer"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1hrffg85q6gph9rktyluglcwfpffh2t98jctu3c",
+      "liquidity_token": "terra1gm0vm4fpr9xe93tw3nc2vdp9ju3g9knwd75afn"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1jsxp2vt60nqfsuru6s6ewgfld7vpwgkvv5qqgl"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1dh2kva6kd99fnq0xa0rn3yjp4dqaw7h806klyt",
+      "liquidity_token": "terra1wlh8acne68zmuyp4n2rmsnpc9atay9s5xn3s0a"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1jsxngqasf2zynj5kyh0tgq9mj3zksa5gk35j4k"
+          }
+        }
+      ],
+      "contract_addr": "terra1yppvuda72pvmxd727knemvzsuergtslj486rdq",
+      "liquidity_token": "terra1mwu3cqzvhygqg7vrsa6kfstgg9d6yzkgs6yy3t"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1js38ca30k0gt9rz53jc8x47yt638l8f86d5lpt"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1650mr52prhczyyjz9rec0ye38q5j55v7gq6wc7",
+      "liquidity_token": "terra1srmemhy8etjaam7ksnl2062x9emwg7ykrfvnz2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1j3w0tswl56yxduhen4gnela7m4we86w9xkwaee"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra10yg2w6s5c38shu0l6mx0gn8u8ctdp8lr9xdplp",
+      "liquidity_token": "terra163fswxeuysgmnflm2hl75elytulp9qnxu4muqk"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1jju99w456sm6w2snkmatm00gve7cvvzda0j6pn"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra19crn3jxwjspu29kc8ftn27lw5vr3vzk42qar86",
+      "liquidity_token": "terra1cv5l73x70wjcs7tz94tz24y874wgu8xktn02t9"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1jjuc3edgk8rjxq074wuusg9nfy8jwe5c68qv6r"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1zktjl62e2hsv2h8mcfs856gu9tjgy58fk6wn6a",
+      "liquidity_token": "terra10l54yyxus354jl80v57npylas00ktj7vpedml7"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1jn0w9ttjavzqeqmp79jzx3da6dx3p6jwmm6tk2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1dpr00kr7ue4l2ela76gx28xe3ck7sjh54uakxa",
+      "liquidity_token": "terra1deuudm3p00384w0uvgrg74v2h0w22tf6k0cuud"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1j4kt7mns290trwlwyxrun5n7nlfkxxcak57ck2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra12ka6n7ujku9wzddy56war52dqmk2hfq7ysdwpt",
+      "liquidity_token": "terra15n4mgtumehlzy3h4ldnz5m4vrp7n3z8yu9c005"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1jkrl0xap6ptp8rd5lecp2j2sx3kws8rzxljsxn"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1rr3rf5kptdtemsmf3g3jl8sy8rtamz2y6mcyh4",
+      "liquidity_token": "terra1syzg420suxvcarx38k7vep65tdqmpnsuth8a5w"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1je4ll79zmy03zpl4wdhgmadvznqr08tzrncpqw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra17nht56uc42wj73z8u0gs5n2x9d74ur7z76vmz6",
+      "liquidity_token": "terra1q5a6apsurh9hkvql2mj2l688dxgm7hpyuvp5cr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1jm9jv95f0w3e0kk3kxxvtqg50456mf2c92xd7f"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra15nqcvvt4mag63ezmejxrdqehsydn7d3520hx7u",
+      "liquidity_token": "terra1d9myqs75njsaymp9yhrnzkkwhg0rsv9gpwcx60"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1jusuf8pcuw56pmj0len5tcsdu9dm4xpqwqk48p"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1k8dax754ampumzvrkq9770p7x40tnvamglg8kd",
+      "liquidity_token": "terra1njsea05lp96jt50f7nc0euc8sjmak6drz8ajdf"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1juul8ypgcs4wtuqsc7fjv76g0tq77nc44ymxph"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1hv6zykkt9xjhuqzumrkpvp5e9t6hrq0837c576",
+      "liquidity_token": "terra1mjvdm5ahr6l9yg2h6sn0khu6y2dkesfmy9dfnf"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1j7p2fxrzryfpzrrsfe585klnkqutg94kca9vtj"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1pcwu6flzc3srtu44cyvt8c7dn59lkyckprhqht",
+      "liquidity_token": "terra15ggrlf3z0j7phzunfh90rjscuvrx4hgfljxhf9"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1j7ft2ze4phmcj4x2mnr7cfcns5x5hqjnnt8myj"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ta3lth8wu992m20qjeucg59rlxeez6qeygsxtm",
+      "liquidity_token": "terra1wtaq3g7zzdshtn8w4mzllxs7mfjh8m8ewtdh3l"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1jl0egxpdfw0eqkzsgedzzet9zgwmhet2rd3s6u"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra10zcf3z97m34kks7ly78ydshrcqf57fttc5sdrt",
+      "liquidity_token": "terra1uysyjwea5505rk3h6caeax3thnnpfp4vx885gp"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1nq9epqtswmj7uaymsw59w9n5h5e78k9rwduets"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1u2e5r8544d7eg9z0nc69afchqess5jlxy7zutn",
+      "liquidity_token": "terra19cwtjx2xcxqrkyrxluew69yfn8e96vy6yg6ued"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1nywvm8avu8medrj84x9dxdc4gfdqd2zg8gv049"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra13l4d3vq7kurmyah9fxcjv8zdqdpndm9n0zs954",
+      "liquidity_token": "terra1nwe7rgzr8uk9w90h8trgppew6kf9x9a3jevpep"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1nxwnngqr0ks3j842jlr6pnrmd79kztjqyycer2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra10f9t46rjhxjdm3324kkadhsm6adqhzva3y2g4j",
+      "liquidity_token": "terra1tdhcdlugvx4wwx9metx92nqpumahw9mzn7mhrs"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1n8awtfqa0wphx90pd2zc9v8vccc65f0gvv6rq5"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1pr0nnzw0elpqk8q2shc5gjnzaz95q4j8qy65w3",
+      "liquidity_token": "terra16znt4xty0md2k7e6evq8thsumhn6lm4kavqzzy"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ng9dsq2m5mw993s0uljj06scrj5g07sq36lq8t"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1f9l20gvf6vd7wtkga89n2vu69jmpqg0qyzapa5",
+      "liquidity_token": "terra13tz3rplgkhj3yav5h388hac4a23p5w0cptzffr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ng3nsd3u3emflmp4rv7ac70ug3g87pt930g6t5"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1fzlm4rzcctes3g230vfgcqwth94wupgsht96xn",
+      "liquidity_token": "terra1uvlukgsje5cp6pnczg3y4etkctrh7yjps5tewj"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1n0pfp0ygz4sqpcjck8ntvlhw74l3tzhe4k9xd6"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1gq080qp496gncf20z8vh4sl0jp504dywm3cw5n",
+      "liquidity_token": "terra10yk2ujugpd4ank5pvp2ewr9en4dnlrul0zqeur"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1n3l6xg66m9t342qcvgdqk6md5cqvtatgg8tw39"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra19nhjua64eq04ulurrdayj3u0f6yw5qw6t4mc8g",
+      "liquidity_token": "terra1h30mmqyw6gu5dnresfzdcwsr2ahec5usf0vst2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1n4g9jamjrxhe5yssczrlq55syhxvwqkx7jpkjl"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra10v3f4lprsjx7wsxnmmah99vx0xw8q5zeq8zhvc",
+      "liquidity_token": "terra1v0wxjtv45n0emx87mlx8y8qy5e449wcj3t3gt2"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1nkf3aaal2j93pqdtytf73x6dqnpxy2u75ezauh"
+          }
+        }
+      ],
+      "contract_addr": "terra10css4arzlu5ws98tz8dmsclurck3lawgddu0nz",
+      "liquidity_token": "terra12fprsw8chwm405m92vseldjp72mwge5ldv27nz"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1nh6theuhf4pv67pcyqnz58czljr382mxrp2rdh"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1edmq655dxqjk4dh52z6e0h9uajs5g0yl5lk7y7",
+      "liquidity_token": "terra1dt5n5tf9afjzms493nfkt3telqtvp5mmmftu0e"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1nccuq0ujp4hc84kjmfwjc3002z2q7xzmdu6crm"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra12y07m3ra6x6qgl4jl5jt5t0qvk7smft3ye4l3h",
+      "liquidity_token": "terra1jv5v6cskf8atvn0hlnmuhp3vpqypk76qjw9xxn"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4"
+          }
+        }
+      ],
+      "contract_addr": "terra10k7y9qw63tfwj7e3x4uuzru2u9kvtd4ureajhd",
+      "liquidity_token": "terra12v03at235nxnmsyfg09akh4tp02mr60ne6flry"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1n6eltvex47mta0me66ygqw0fgvjx2ul7qm9fjp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1la2j3fggypkv5v7rc3vdrs6f3nm5duexd7y4pj",
+      "liquidity_token": "terra13wn4sj9c09638wdxn73d2hgzlzg2dp5gh4fj4c"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1nl9dx4pkat90gzw2j99n338n984e4cw7nxq65w"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ndvg44ygupqwq8xqzvtyqjq7agl50wwfpm0jfq",
+      "liquidity_token": "terra1fepqumj8lea8w0au7mqluuthv0jly22tx0rcls"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15q3lzrnfstr3rqgh55cqmp95z4xr3we5tfyqm9"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1c9t0gzff3z4mh62ky9cj9hkunlj8zqz58kqa87",
+      "liquidity_token": "terra1gmuytg024c2edzq3hdkk3quqzcttpnax0cq6el"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15pr9sk7qkr46ys4gaxmsyl825m4fgl7fdjwqaj"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1urmuf440vzkj48uh7x89vgmsp3w4tyzs0dln02",
+      "liquidity_token": "terra1uc59nf6kzep09k4fruxh2kzfq5kztlqwrnezk5"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15pv3xxp2d5f65qeu2v27vqf9zpqjx0fuztfwcu"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra14dvkhl6xzg7dj2e60vasr6vcvh3354wwnfpv0d",
+      "liquidity_token": "terra1s26qlejx4lhqd3ruc7tp2lg3xu40rk2wpxssrn"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15plvf4hfgsrev5athn7wmnqgt6f0lddmduzp90"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1c78mey84ygre2ym4aznw28796qfuytcl32p83j",
+      "liquidity_token": "terra15gpwuqw3uezt69vxa5ftd2dt7yc8ap2fydqhat"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra15z4tj56cdpdk5jxf28nep3ep0myu0frhlh6f3u"
+          }
+        }
+      ],
+      "contract_addr": "terra1q772ps7jxy57kgfhhpmg8gxsgn9fr7npwsn4kw",
+      "liquidity_token": "terra1jm8tx0aump43epcd8u0fspqp47agykvmmfrzh6"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra159tnr8a3uutvwxhgkea4f2hucm4v24evv2se2t"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ht5zgyecp4w7s3jzgq9j4unjx44hx4se94yp62",
+      "liquidity_token": "terra1qts4ddzv4ndsv4mkccazupmfx8q978g0kr459n"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15xf5wqprgzl59ckfyjtgavh7rqtxcju7gn57rc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1pqpha5xe3fhtvyplcuwyzhls8hgdupahujpyay",
+      "liquidity_token": "terra1gdndzwhsua4zw90pef309ked5h6npusgcu2j2c"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra158y6aypem94yj34ycvgdm3py23afhnu2dj24ak"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1sdu63qdzkndpavvl5ephzwl7jj2slvcy89qu9s",
+      "liquidity_token": "terra1xl5rv3h6uw5g26halsl9lyz4p9pa4hgdle4pru"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra158gqaxafjche7vtew0f4zk9g80224qr07kwfsk"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra13vj9z3cjvtg0v7uu00m4pwd7qw5faznuvr6mhf",
+      "liquidity_token": "terra120vlcdqz23ssmpvdeysq75a47pjy5shlxya4zv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15823sstx9pl2fqacnpaxsj9jsku2rjrk4aj34z"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1y24vfnpcr0f037tww6t87cwuxq3dul74rstkl0",
+      "liquidity_token": "terra1ll78pl5a256d7lgqk49mc0r4cj9fnn544pwr0e"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra158ut7lycly6ep0v334rpjtcjs8hlvwjzf5tfrk"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1c59fgnldauz68wpxzawxy7w650r0yvhq34g6ng",
+      "liquidity_token": "terra1fgnzu8mwnmg6utjqslrw5fr08yqxeaat88gfc2"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1587zn7hagaylrp22x5edz25zpqfn6szfmvtym4"
+          }
+        }
+      ],
+      "contract_addr": "terra1n6e0tr9f2ygkjthy56ckuhxrzs0xa5jmtw7guu",
+      "liquidity_token": "terra1ptsj2ufnvp5nv5lf8gtxek7c44rlztppedepfu"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6"
+          }
+        }
+      ],
+      "contract_addr": "terra1amv303y8kzxuegvurh0gug2xe9wkgj65enq2ux",
+      "liquidity_token": "terra17gjf2zehfvnyjtdgua9p9ygquk6gukxe7ucgwh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15fvz44vh89rj4ykamk2tadw0f7wdnccn5qp0ua"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1haarsvn3uxmul3rt5vr8x0856pjj45js6fwkhz",
+      "liquidity_token": "terra10pkxzyxsxxrpumks8v6txn8ym0z339nrjf6fje"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra152qpnfe76pnkwe8msfjxf4wjq0tcjtuuunv7eg"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1vzd3vra0zfnug80gtuwlc2j5rtucr87qkh4xmf",
+      "liquidity_token": "terra1cz49n0uhccm0qdyd4crhjgrvrfhtucelr3u0fs"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra152mtjjndwpwvtszd4cxnhvjm8nzxv6kdwtdugg"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra194d6fn47g5lztfxl42fq37mwlnd4lqwestky0x",
+      "liquidity_token": "terra16wlnwhhd0x0jp9lxqnms2ssmsdhg4v206uwysv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15tqztw9vjcuc9znkvmxn7rh30ffdnahhnw4vym"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1cr8m0mpdj5e7m34ekdrqgw59az5v98pgckha4y",
+      "liquidity_token": "terra1dsj8lxhuvtz8k8vt9v7zjm85cca4qjhsqgvced"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra18adm0emn6j3pnc90ldechhun62y898xrdmfgfz",
+      "liquidity_token": "terra1x3musrr03tl3dy9xhagm6r5nthwwxgx0hezc79"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15dcd0j3tqtefj96nhqryt59qyr820tyxq3l0dr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1mp8mm0m43s926dqmwv3mgfaagvtpx8e4w84ur6",
+      "liquidity_token": "terra1kg0wdgxsqgy4trqmjmag5qd00hlygh2df8th8m"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15wwvprh6gddrc7yvshghc2g944ufsq79ay94da"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1q7hat4ymhtawg8agg70u74m8eu3q7qsg9rqmr2",
+      "liquidity_token": "terra1m7gu655my73ulr42zhaz466mgl65au8dwvp3vj"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra153dl24ah2wf95unv2gavz7ezldcpnqyypcxf4k"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra16erwvlc3tjy8ayuxt7ju7rk5thrvc0yk9txtan",
+      "liquidity_token": "terra10hs57x43jrc8j0mxxjsh8rsp5cqym7gxa3f49d"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1534wdj9s0c3c64pmgqk8544usm0jvfysn9zq2k"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra16k9sv0425t8prauxk680sj8aecgh4t948v8ktf",
+      "liquidity_token": "terra1d4x2hk2gqua29fn5mq5nqq9nm9vn7qu0fvnfzs"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra153u8c40h2mm8nvs0daqxsnwgvpw43muxj3c28h"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra14j82htz2rhn47jasltna6tnqy4gy2097zf2pat",
+      "liquidity_token": "terra1sa4y2x977nn4a9rlvpajx3mucyq2qhwhyq6gct"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra155kdqp7le4fw8z8m7wk6c62d6dg5mgdug924nq"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1j4nl03rhuf9ww53w0626jpng4tz40qm5uuqgnd",
+      "liquidity_token": "terra1susaylhx8sed45ljaww6wrdafqm7hccxhtwyyt"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15kqr498g9r2j5mnddy27qgppcp8a759lcegsz0"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1le9jy02n73ghxkus40dldgrpeez24pa0t0yl65",
+      "liquidity_token": "terra1u4474h3hqesjwkrtkxekjw065fduc92wke4clq"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15k5r9r8dl8r7xlr29pry8a9w7sghehcnv5mgp6"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1hmcd4kwafyydd4mjv2rzhcuuwnfuqc2prkmlhj",
+      "liquidity_token": "terra1qq6g0kds9zn97lvrukf2qxf6w4sjt0k9jhcdty"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra15hp9pr8y4qsvqvxf3m4xeptlk7l8h60634gqec"
+          }
+        }
+      ],
+      "contract_addr": "terra1q2cg4sauyedt8syvarc8hcajw6u94ah40yp342",
+      "liquidity_token": "terra1jl4vkz3fllvj6fchnj2trrm9argtqxq6335ews"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15uc875u7uu8xyqf833nxwh5x4dm2kmu29u04vl"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1gnwt6a5t5vw90q26va9fj3j0rsnjemptht0szr",
+      "liquidity_token": "terra1ewm8kaj2vvh2aknjzlv6cyqm4hjc8j0uvdnah3"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15a9dr3a2a2lj5fclrw35xxg9yuxg0d908wpf2y"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1jgvh68gc0zedgrs0fne2y8r0zvc2z7u4sdemwh",
+      "liquidity_token": "terra122pv8ln4s5kled99288gn8sfk4ep5pw05yynez"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15afvt8ch38n8qj4n6wvykwkl2fqvfla826qdqe"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1rjdh8dj7jrjwz5dul7n8m9eyne92rvzftnjueh",
+      "liquidity_token": "terra1684j38r062hr2nlwgf4ludpt9zk5g24g85syzj"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15as2k330rp40z3yp8ufs2uqnmdurlzgl643fsp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1fggg5s5eayyqm46p6m27xh3manl6c4pt8kfvn2",
+      "liquidity_token": "terra1jaw7xw5904fsarqgugk0h4tl32w385zv5zaax9"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1572yxtl5yxa9mjyzg44gj6knemudreekplelxh"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra12qgav8q2qa5x8me759ajhf3j64525qumznc8h7",
+      "liquidity_token": "terra1u3m39v7vs066wazhl3manl8ztmyxpafw7ysdr2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra157n30a667ethsknneaavga2txtze58eajyfv45"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1k8fkje4xawkgtg0czxkp98qd2gu8uz4xgnuzsv",
+      "liquidity_token": "terra1pk0vx4t0aum2jlyv6v0hanq3unvkhl4lxp6zl3"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14q0a4tfmdkwrvzakv7nq9jg2d36w8uj9jkhgee"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1a852hrcu4rsafrf9wftvqstl2vqn2argplnnmp",
+      "liquidity_token": "terra1kdx0f3un67ds5a0pnx38krgpvkfar98gl3myfu"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14qs03ha38aya45vac8q9wn8pjy92knwta2exdx"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra15c30300aaa2gt43svqy40jedyh7mqgn02tyukg",
+      "liquidity_token": "terra10xqkk0p4nmgmpkh7faudc0ftmkcx6lhd23vc3g"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14pv5z9j9auwf7p4dg3ds0gch8sr8gnnf0psk8c"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1jyqk0rg9wty4nvvxej9qhnsg3ef3agcc5nmkqp",
+      "liquidity_token": "terra1llqsh0fr47vxpgv2s8l0d3k8h2g2lqcg87zhts"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14pwhc79alqnxdhtzm0rrxt64uh4s568u8mluhu"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1kxvdprmwjxpfl4e87vazwmzdu3pphxgkmt7j2v",
+      "liquidity_token": "terra1v5e88rv3easl8630pf8g2ylzlg73nv5hx0km4k"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14zj58ljhlyrgshe0n99un3k5ll2s0eucp332nu"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1eky5etgq3jwhtyz2tqyuykkxpj6rep7jd7v7rq",
+      "liquidity_token": "terra1054t5v3fszukf4hajqvf4zsndcn2rdx4yz8crq"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1gm5p3ner9x9xpwugn9sp6gvhd0lwrtkyrecdn3",
+      "liquidity_token": "terra1gecs98vcuktyfkrve9czrpgtg0m3aq586x6gzm"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14zeffuryjlzw566k7cfrnzf9dy94qeat2xvcda"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1qwk53cmt2j50ge2vkmt5sgcnmua5va5gx2s6yr",
+      "liquidity_token": "terra1nazd47xg74dg4a2eld2qxaynarv67d2l24z3y4"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14rq6etqgza9qqpgz9yjfmsclgnzhk9jsafdtyc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1c5j97vq48wjln03wgtalfhlmlg6uyczmpj74vj",
+      "liquidity_token": "terra1we6ygtflu43kjgzj8ug6d43f4zkd3fmssax5sx"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14yyepy06yw57f4x564xrfwxvv460vq0su5ype8"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ng4tm5a9sru4cgwqs77tm5fh47tt4sh6glzd9l",
+      "liquidity_token": "terra167c9s2r2jkze9xe989wfeek2zkc87ggjcu2u7k"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra14y5affaarufk3uscy2vr6pe6w6zqf2wpjzn5sh"
+          }
+        }
+      ],
+      "contract_addr": "terra1pdxyk2gkykaraynmrgjfq2uu7r9pf5v8x7k4xk",
+      "liquidity_token": "terra1ygazp9w7tx64rkx5wmevszu38y5cpg6h3fk86e"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra149755r3y0rve30e209awkhn5cxgkn5c8ju9pm5"
+          }
+        }
+      ],
+      "contract_addr": "terra1u79vnslyaxprhmeqla6lj7dkcecg800ssclhu6",
+      "liquidity_token": "terra13sjghs2r7seamgr4g9c4p2eeacknggetsrhcar"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra14xulq5g99rfmrm6qkgzmrrspvknupajdqyd92k"
+          }
+        }
+      ],
+      "contract_addr": "terra1f22zcf6m4600eajay6wnzw03lmjdy0f8mjxphe",
+      "liquidity_token": "terra1ungyyyachxaszce53zstctel0mpzactmtz8hdp"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14g3uqp52dwk9qts40mr2skynkqdxsqwlv0862z"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1hjpke0qekl4q7uy758c9z5ve6xwsuzz5n783ek",
+      "liquidity_token": "terra188ff6qfccynwu3ge76ylp0k9hm9ke3fsnacmc5"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14f7u8z4eqpxcrp4xr6knhgfp5n4h68nwy3yzg5"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1uz8hhjwg3472744kgkz69jfqf3d2uwl5aw66mw",
+      "liquidity_token": "terra1svt83amwsvghu9elhme382em26vupp0uprur9p"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra142yp486a6jjelr87c0kx6vxv22nw6dsvkcnhma"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1crkwlasutngkqdlfskk7rcgasehpq6aaerarqd",
+      "liquidity_token": "terra196f5vd4s9zn6deqv9shjktk348nk7k4kcl4apd"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14tc6kg4my06ckzugrukq0r903sup3a6agdmx4y"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1pvetz858samujj0gkx7rr5n8m0gcy5gz8lcxz5",
+      "liquidity_token": "terra1kxqugyrr0e4he5furrqrehr8qhzqpfxxnt3vlf"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1peyurud64sjajna3s9g2s9er4uv3tftyj9avwf",
+      "liquidity_token": "terra1r3zg43ftsjsgtm8kwyjletc3u57ut2ee6t08jh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14vz4v8adanzph278xyeggll4tfww7teh0xtw2y"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1hqnk9expq3k4la2ruzdnyapgndntec4fztdyln",
+      "liquidity_token": "terra1kg9vmu4e43d3pz0dfsdg9vzwgnnuf6uf3z9jwj"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14v9wrjs55qsn9lkvylsqela3w2ytwxzkycqzcr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1nzepxu4scprmc6ly4amam0f2teufy69uu02wzw",
+      "liquidity_token": "terra1v6s4drn5hyp4jhyn797ddn8w3zjxl50c647y3v"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14vw4sfqwe7jw8ppcc7u44vq7hy9qa2nlstnxmu"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1wcpqg4pr62dku9cry6r6xp7pagarvtzjtpql3n",
+      "liquidity_token": "terra1ufhwwlu0yj4cprnqu0nzrr8us65whv0pmprvfe"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14dtgwushpvu2c8d8rtc58z9r2t4p67ug8wl4d7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1pxlm7mjmqc4h4ht494jvmmwq840zn77eyex8yd",
+      "liquidity_token": "terra13e46ch6vkx5yyaftp69f66lplm4uxhdze958ze"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra140k6k2pmh2lmy4q4wyz5znqmtgwvs3gkgfeevq"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1stdzf28wlq7llzfecse366r657rtdh6wtrdfk2",
+      "liquidity_token": "terra13cvk06h0e64y3x8c3ds3lts8pwfq955ypw08v5"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14s3g6jmytjjg2jcxmmaj6k837vcr6h98muxc07"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1v97030v5lhr3f65qen0pc5k0723qhs5uplxnxp",
+      "liquidity_token": "terra166y3h6l4k42lrrj83y4lp9cdyqyxhv4cnkrjs7"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra143dkyw98s3ksxu97zln8z5s220ytatygd5rqdx"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1evfprrp4l8kratzm3hs2yxnly2t3ps2r5x7jh2",
+      "liquidity_token": "terra16kvs9y46p4lkj0dnyef6ly4fzs7883ztl2l9dk"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra143h4n4h3j36z64t7l8ey7vny6x47ukpz8s2gvs"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1v9lxv5kje00972tyf67qp7gwdc7msxwr8wf0j2",
+      "liquidity_token": "terra1ty6nleg3m2lq7rfrlsw0adulaevsk76p4mfups"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1450zslle4uv3rvy634zva3sv7y04zdf9rthvjt"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1unue6cp22kh4shapxg7ds6ccmkp3lhe80gh7vv",
+      "liquidity_token": "terra18uujlxknf5zrlz88c2chjrucxm8dxwherdq5y2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra145nmjpjhergp4uw02hp079phtnedslmxv4v3n5"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra14t9rgrx4t53un932r8jtcsgtrqqvvucndte4cg",
+      "liquidity_token": "terra1ga4yfg9uclqmaeg8trv8yaydm9ufh82cdqea40"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra145627szryw7lxr58cvclx9aj468qupld4vnf88"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1q4xywudqrgsuvdc0n9w0mhmrpzqj9lrl5wcf6j",
+      "liquidity_token": "terra15pclv9fqytszqlmjymshyk9cfytaaqrs4h87sf"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra144w7e54fwkpz2aavq33p6d2upyc0u006udf32g"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1n4cqpg6yrgrjy3znfyx0pka5gyh6hysv5vqudj",
+      "liquidity_token": "terra1dp54cd4mq449w0x6gnxlw6v0yg9dtpjpm4urv3"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14kat7dptmcydvhn0l5ur3g3evs65n33925n7w7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra134ce0ucmswxcsjl0st8p36hgxk0edty06nhhv9",
+      "liquidity_token": "terra1p5qffpcsqjk6t9v0dn3luzj2lhxnep09d8pgep"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14eqahu3wavvesuyplmstsrnfu7uglxxy3m96dl"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1hl4624c6pkza6jyxnzpyxf07vyhuwt34c67ujf",
+      "liquidity_token": "terra1f2mpaw7jmm7jzhkgf2x7yg50vr9m4aplu7gkxg"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14ec8v4c5dnwu2pq9plfquaffutu59tq9hld77e"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1gk2nnql0vllx34dev6l9grl425leuehckwpx3d",
+      "liquidity_token": "terra1zg9vp5w4xtasrua7kx3rn4smm3e2nrda4u3432"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra146fhkmq8d7ae3e6jemufy4h5eq9zerftm8wzmt"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1tnt6qdre3htcd6wwf2asj40ch4fys5x5wzz35v",
+      "liquidity_token": "terra1ldlsayhau0qdj92j9r5nzy4mfr2gunqv6qukdj"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14mvkydkwm2pzz62cgrkpeusphm4trrqrzd88ju"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ntdceldg23ymqljh94wcp78dl6qmzndq8u2hwa",
+      "liquidity_token": "terra1swpfg0q9uz0ct4tqfdunrumnxx8zxxzdlnlfkw"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14a2t4c4a8us6q24k2hkfm7kdenzxu0yxph35wd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra13hmvr56ld8lhtdxkzw9q08lkzscnjlsa8jff2r",
+      "liquidity_token": "terra18y8qtp8slkdrfdf8hvfjhk6w7rn5vm4hhegngy"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1478yfcsa6ycykstdfh2mclwdy3d6zpemkyfu4j"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ahygklrmejad3mmeugsd0m5lczv9jl8hjepp6r",
+      "liquidity_token": "terra16k9tt8q30dswt9ksp00wrfdmdlze9s2en5y7ts"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14lpnyzc9z4g3ugr4lhm8s4nle0tq8vcltkhzh7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra146c06de7zllrc3r960dmxq4m5q076fvw95529p",
+      "liquidity_token": "terra1s0y08x9qxn0xy0ph43lk24h8wchzwx932ewlej"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14l9lspj9lp2rpnhp6qjpruwcqst0yvl9cm6l96"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1psuy4666c74vz9exfxvupsxmkgytneq7gushws",
+      "liquidity_token": "terra13084cqs5f65aal0c7m4zefh7785t3wvvw6dx44"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14ldz32u9l0s9lh07zqqqxgmnzwyww04hmvs923"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra16qjw56mjdzurqualderrjh4p0gprm66yd02dar",
+      "liquidity_token": "terra1ks60j2lj62jrpcn69eejtzvg0gatjmz44x0l6y"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14lmsae6e4d5lu74yt67pkfsdaut4csjtq32a7x"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1d76u99glatdeep6qjkhg48u2a9fvuejcwnasut",
+      "liquidity_token": "terra10etw4xh7ymehx3ngpknfa0p9nq2w7c97vhjzw8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kqsgl8p84szmmv0npvsv0u5qlq5fng3zk8c4w0"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1pzhcs3l028l8dzvj9hvxgt93ez4uq203askad3",
+      "liquidity_token": "terra18jwvd3w34eudhvz97gtut5qtas57al7ez0kg4c"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kp8vne240370hn722ec5sacsdluyt2j0gc5nph"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra15ytncdwh7yqttvvxjmw7cd2phj9a7cyldv8547",
+      "liquidity_token": "terra1wl74zp9lyhznusz7p3xcag9jur58njc7fqa0nz"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1krg7amkeenvqwkaarp4r4grmrnldd83lmkl26u"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1hy8zr752587d0l3qf9gy4ql4a9ft07wk88ssn7",
+      "liquidity_token": "terra18g7xmhx2ve5e6agjtmk6w3k6j6xtn5mds9jtkw"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1krtfgcavw64dc8nhnz89eafpqm5pdz95l9a89f"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra162ccsqcru4zy55r4u52rlm46plwzvzc2x67meg",
+      "liquidity_token": "terra14x387d844rddafa4v2swz89tljm2ux59qz954z"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1ky3uafsw2kkddrhm039klksqkuwtdsfsmpc748"
+          }
+        }
+      ],
+      "contract_addr": "terra1pxpdtcydzh59rxwdnz9prs92emws7knz5gmugj",
+      "liquidity_token": "terra1tmw02ugjulhezj868pu4s6mhlmshlez7thzane"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1k9evrk369dk00mqgrw6sf678asel5pvtw5skl3"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1zvqegk0p2q8k4034uy0lakw7eatex4kp8qd6m7",
+      "liquidity_token": "terra1svnmp58jrkwsjcv6d9r0ac6rgqh4vq7mjnfyag"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1k9ltsdc6e4ay4g8f8nt8qd7my9yyd27m7eh82d"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1sx3clxk5yhqjq5j5q87jw7qu27cn7en37zk323",
+      "liquidity_token": "terra1hggkcl2v8wxzpy0vzxf2a5chw2h2fh7avl7j86"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kx4y3y4pn32jssqr90cj0rw89ds98dc0t5eqfp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1rpcz0746qj4f6nwcpap8z5knjpf4fj6wmalupy",
+      "liquidity_token": "terra1wspgkqtkul0m2qc7rnxsuz0t0k0q597ahelv29"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kx73zld4tmv24r66h7jp8gaz2rrl4asxlzq2g4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1kx5dge4hsm5ke5vuxzp06as8lxv0d5dwl54xep",
+      "liquidity_token": "terra1ug8jeyh65zxffe5wwj3j88fntdjdaj8xft6g95"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1k8fakrhcg5h87zux06hlds3eswej8389l8fdlc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1fh2j8kr484725ra3hwc9q3j52h2qdnnwargzhp",
+      "liquidity_token": "terra1a3n5ryr8ud3mw0cdu6gm8yqdcjjmelu5d79g7q"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kggysvv0q3tq2r58f5nt03hqa8pqj87c2m8k09"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra160d0llw8udxrv05jp2cj3zzekdhdfgznshe3sa",
+      "liquidity_token": "terra1t9apa4zedk562wam5xp7g5gkzlamzkwle6d5av"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kf3ez7z2kzvvv7z7kte4en35gxm8keurgl09nj"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1228ck5ztqu455fye2yg8jwm9nr7w7yzdjqzj8n",
+      "liquidity_token": "terra1gggcqzd4su09erq8e3g8f9qdf7dydcj7mj9qdc"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ktrxxylv7796wsd8rm7u0dftqhrjfs75r72wnn"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ctt2k8euhqny20vqynjpxqv32nlr0r95gr2eeq",
+      "liquidity_token": "terra16r76trzhj48rj8tmq82f8set2mm6v7qrje3rn3"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ktugzem827nn5uh2ccjk8y6xr9z4szvdc7x39r"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1hcqrfwnjvsp6y0hyp9sgfla6k2fqx23g9j9q9s",
+      "liquidity_token": "terra1k9tcrhdgh2q5wpzw8j4ap3fen3ryn6ycdmn4ru"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kvjscdgwuvwc6uzm4rqfjl6nlmuhj28tequlnc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1uvchkwq4kv0vhy23c78hyy72zks2hqtpctklh2",
+      "liquidity_token": "terra1pndz6cy4t42qae4m7avkjjyu6vlcrlrx3hep0k"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kd4rfff04cvw7vae0szgawj0xye90fkchljv7y"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1kgytwyu7aqah7cm97xeeurvsj3n6kxp0tc9esu",
+      "liquidity_token": "terra105wahgnrx7t2dsxfx9wer2mtcfrvfpr5hjxyt8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kdkcxnsldqmj50ll77gmq5x26u69z8m69hdas6"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra12lvqty3v0ncnxn3s4agekcp94akp95n7qgv289",
+      "liquidity_token": "terra1va79wsdl4zrs2f9z2eef3c76p7akhuk3n654gc"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1kscs6uhrqwy6rx5kuw5lwpuqvm3t6j2d6uf2lp"
+          }
+        }
+      ],
+      "contract_addr": "terra1f6d9mhrsl5t6yxqnr4rgfusjlt3gfwxdveeyuy",
+      "liquidity_token": "terra178cf7xf4r9d3z03tj3pftewmhx0x2p77s0k6yh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kn85pdmrhhk2upjj8hf97lx3w3jg6gyzasyksp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1yvfnqxcksy6007sp6rfu776chtugm2u7qfhved",
+      "liquidity_token": "terra145t3m07uxx2xr063pq8l6hh6wysp2d27np86pn"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kntmj30tuu0fyu7vmgcrxuzax8gzt7mdmuppwv"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1hgzc444yxhgrdj4g9js9j87uarvsk3ze0uv4mn",
+      "liquidity_token": "terra15rsfzmyk0vfch3dg3wve6l2cggppmuuyfxjawx"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1k5hx3egz7jnzqs7n2ze0d93mce80y4cndd5saj"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1lc2jzj4x8r7f6asy6vf9jlwnjpuz83vuruutkj",
+      "liquidity_token": "terra15s5dsy04dkplkf7k8sggc5nwc40dhnx9eektvt"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kh0w04u79rhwvchmjsd7q4xxlm72y5wpf6a87v"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1qstd3t9jv9v24ew6v430c42xfx9qf7mg7sg28d",
+      "liquidity_token": "terra18zs698tsn3600gtv4egtzx34uppcahzg7qlh8x"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1qpd9n7afwf45rkjlpujrrdfh83pldec8rpujgn",
+      "liquidity_token": "terra1qmr8j3m9x53dhws0yxhymzsvnkjq886yk8k93m"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra178jydtjvj4gw8earkgnqc80c3hrmqj4kw2welz",
+      "liquidity_token": "terra1rqkyau9hanxtn63mjrdfhpnkpddztv3qav0tq2"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1k637r8ucfp585tv57gsnqzfdmsw6mnm9zn59zy"
+          }
+        }
+      ],
+      "contract_addr": "terra1zr24fxhh5hf8k9vqv0xp63rhyy2g373m83scps",
+      "liquidity_token": "terra19ekpmkxnysep0tuxza66z475vfd79xput6dw9l"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kuf3mxgrcwnlh4zfk5p5c6tcv436j5kza70asm"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1hq3kf4353m5d858u08mymad5rvgkc4zeqhr8vs",
+      "liquidity_token": "terra1j02hv8ulc5yg7hc79ycsxfhgmys7jjc0m550c0"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kuwc30mjvwx8jysn77jqq8mamhxn7tvxlpj70l"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1rn4fnz3ev568twtavaz4a7wmpfxgsk5t79mst6",
+      "liquidity_token": "terra1vm8kxc6wzvkmqyh0rl6rdzmextnwejnlmz7u8j"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kujvztl5p8a45k56u42fq39jxldxcvuejtpfq5"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1z0g2y0d3eemtcsd253qd8vpl74a089deqas2hp",
+      "liquidity_token": "terra1uu0xsadf4x7v5q9vpgp2dd9t9x2khwqlal5rl9"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kafnpwanfluj6ne5t8ayg8ykarx060a50l72sw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1qxvf6f92f38wznvpyjqcd8ncppffuva79rvdeu",
+      "liquidity_token": "terra17ctyhfrdw3ppnddgyqkx72fqxsc677whtggejr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1k7pvdmk0z4hxhcncanp4pxl6ev3hqzeekzu437"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1c9cu5ny2kc0j2njj4lydpetgwrjm9t3raqu4tt",
+      "liquidity_token": "terra13698ymrlv2xpy8l28r6qx5fx420w744zg24qzp"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1klz458efcl7md99vafn5sdxtluauem0q5nqjtn"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1wvnw3nkwdx7ut3ua4wwm5u0lf7sl3fqgy8kltl",
+      "liquidity_token": "terra1yh6uxxmr2yhuwrswkhtvq7wq5ra8ecyucdtewh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hqr3l4je2yvn3l790ly0y6r0vgfs7yukwwj0ak"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1qeueswrw9x20zncjv624lq25nnk0rjfzckc7cq",
+      "liquidity_token": "terra187svcx6sy4kxxq7mz0saqf354kwf8gjpdh72e5"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1hqgzrrtsft73pjnlf7w946u3m70a99cxjjm879"
+          }
+        }
+      ],
+      "contract_addr": "terra1t7zq9ujczprlqss0dec7akfmnc2wumvsl8dr2v",
+      "liquidity_token": "terra16ejsp5mhav3kppkj7w438spp0eawknsj0afhvx"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hpz206wxjhta4x83ukmk4v9rvk9dky2h0texf3"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1q4nynp5mp4yhtxkyzegdkf594h94hhycmgxdq4",
+      "liquidity_token": "terra1s6acdmcz4dnphyw8yctl9qmkxluj8u6snankqq"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hpkk7ar777hx8ne5vgkkg5tvntm8j9m32w6zam"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ghjp8h6kn3rgtdw6kgkx4h4lnnwdtca90q4ymp",
+      "liquidity_token": "terra1zaj3vee3qrperz3djkmjzhvsdnt80vy2a9szgw"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1z50zu7j39s2dls8k9xqyxc89305up0w7f7ec3n",
+      "liquidity_token": "terra1umup8qvslkayek0af8u7x2r3r5ndhk2fwhdxz5"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hytrupk3argcrsl5x7dv55gyda0tn7f2qqlwkl"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1jy57s4anzh959e6cr02dwt5s3vw03ajwtfr2l9",
+      "liquidity_token": "terra17tjnesmzly8gv3aj87mmtdrma77au2z6756x9d"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hxcsd8ttymrqzp5uh5f5885j0ms0tnzux9jzsc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra18kf909r8usm8l29t6krwtexyzd8wr3vrqqd9vm",
+      "liquidity_token": "terra1cu947swy2q3re6er4f8stuxlxdeljx0umlq9my"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1h8hmr0em0avkz4kzuwgakyxrdvxqwg5d3cg4sd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1830q85e520kyhh5e0a254gvt88z8ngxa05tj6q",
+      "liquidity_token": "terra1u2f86x2fagtz3fghdc4ymc6dat3arepfu3rtum"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1h8arz2k547uvmpxctuwush3jzc8fun4s96qgwt"
+          }
+        }
+      ],
+      "contract_addr": "terra1u56eamzkwzpm696hae4kl92jm6xxztar9uhkea",
+      "liquidity_token": "terra1falkl6jy4087h4z567y2l59defm9acmwcs70ts"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hfyxtste6842zulmjv9n92srv803q6rhn7t8d4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra13eyn98smadfflnm0jgt04q5dqzs3dtjg6kjjrj",
+      "liquidity_token": "terra14y8k4uux6x76wjqdy9vpqqunhtmjsd5vu0jxv5"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hvv3qzmzmmr9qkf2xj928hhy2yxuledwzn2v5u"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra15waumwnpjw488cgchv3x5j7g7qlca73sd4zmp6",
+      "liquidity_token": "terra12cwf2ge7mxjsaylmvpnpcy0q8t65fhevhasuxs"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hd4hgml43g4k50nlyhuntsaw8p7rvnrht0f9e0"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra18em0a2s6ca7j00sa87h8ypdvxw6cyxvddt9a8p",
+      "liquidity_token": "terra12wg09c4azptm8yaw7cadhz8u2nvthj0xm99rva"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hw6q5ecr0gp09v668szzx3qz86w08jru9rqyq7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1yl9lv57fq5txrfzwevjdh5v28z9tt0cn3rsyx6",
+      "liquidity_token": "terra1m386g65qjvcf6nrz6p0ael59y37l5suf6ys6sm"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1h0jk42weh0urhgdtjql93rrvgdccspnp7vyf49"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1p7y8st3wjgs62vs3w9dw2sf603e4777v3jamhn",
+      "liquidity_token": "terra1y3c0z35uju9apsn0faewjdw630tqalhmtpgtc5"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1h067erdar0vs6466jafpjsd7nahzwghtemn6y0"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra13zhrlgpz2zmw6c9vd8lgc60qfysdn97sgf2hej",
+      "liquidity_token": "terra10j58rxwrw5fqurt3yludmp9j7xxgxtn9k2thk2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hj9g4kecf9gncxsa2257w4glhwgrdp7vjsnncv"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra12cvs56jef4cp6xgwln62yp33fapqtr2kfa3h2s",
+      "liquidity_token": "terra1yq8pm98kadrxj835eeknhuhzrhzgxv7hy9nelz"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hj8de24c3yqvcsv9r8chr03fzwsak3hgd8gv3m"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ad4crwtu2vpc0qcmw4xmypcy3asp54w3kg95cv",
+      "liquidity_token": "terra1vv83fgkfng78attun85wqgkp9yue39euyz40k3"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hja2d2790m6hynju77t56nhmmyl0w09s5acqhc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1s9gquy9js5z64eehsf22w2zq7dwr9a7lavuxk7",
+      "liquidity_token": "terra18at36s7ysqaefq929u008hct0amdn4hgfapk3u"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hn8mghxm4qm2g654m3h4rmqccgs2wcdsvsex82"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra17supgps4aqq7nfkcqt97y0jxzh5u6mrzqlg936",
+      "liquidity_token": "terra1jz8tpf2pnpmw5ek8yvc8gnm86ef67k8a4r6lfr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hnsqjjzerf2leaufj7dt9j54nyjvhyppj7khaq"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ng3vjr2av7hgx9029pyc3v6y8l4zy2gf7nrk0c",
+      "liquidity_token": "terra1qwa26w5mdznxf52zug3qegzhq8pggutfqrdq5y"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hnezwjqlhzawcrfysczcxs6xqxu2jawn729kkf"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1mz0p4wzz5tmethu7rca2jjrw077hv2ypj7h06z",
+      "liquidity_token": "terra1mxpq2xc6k7zasj4wmlz07x4wh9la8dqn3nrxja"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1h56g0tp38whpxlgdwcqdtgmrkkdyqerkymyklp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1xen8n3l5sr3z9ad7mmmgdrhy8qa36wa00s45kg",
+      "liquidity_token": "terra1fsvjcrmalf6n9lu72p9cv9rum6x6nhg2343ghz"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1h4wq9krj88hcl0m2e2kxfn3gznga30g5rrm4qa"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1pfkanl8ycczuzyj02rjr3vx3sw0us9vxhpr0mt",
+      "liquidity_token": "terra1n4cydpuvk8encunn0ag2h0y0pnzjkh4y8hr0ua"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1h4hvry62zk4zh0udecqmatfg02phnyu6hq74xd"
+          }
+        }
+      ],
+      "contract_addr": "terra1nsmppls52m3fmphznag3f7lue5wp6ffrp9e4s5",
+      "liquidity_token": "terra1dmuw5wyluxe6hf85x7waepwuqjgs2460fmj8qn"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hc9zu9jx0vy5gt8yl7evu0wk6xvjl0ylnsg75x"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1wl3ravhhyqmtslfrwvpap0xda2pwq4epxd0adu",
+      "liquidity_token": "terra12ma0hyjetxx2w2vz0vagd4huyuf54v4uf69uc0"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hmxxq0y8h79f3228vs0czc4uz5jdgjt0appp26"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra14n525nzgnsqpy5ne28ffj6e2ul3c3n7hkv5ql9",
+      "liquidity_token": "terra1ktld67cnuc592xd6xjgfh2n4d3f8av4mn53lul"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hauj2lpsnye4jsxxww8kpze4mzyq76e5cjr2wp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra16h7sscr2nazyg7t8yfc7htw6tvy96vsh84hkus",
+      "liquidity_token": "terra1klz2hs3a3j3zxn48ndvcqsuvnmjljlkfvxhdnn"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1cqxahw3zls3x5k9sngtyjt5qm8nzmzsleyx8hh"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ufrkf9n6nlq35e0gdjyc5s7qx63mfhkxrsxkmc",
+      "liquidity_token": "terra1wm2rpkpd3n0e6mkjxkc3fy3a2nw9mcrrl0npj6"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1cq4lkf7dlygdp23yql8a4daunnxr4xd5tymszl"
+          }
+        }
+      ],
+      "contract_addr": "terra1afgh029jj9nxglezr3jxmr0heujj55pgspvx4m",
+      "liquidity_token": "terra12sjz9t2pnjxvytczwl6ynk2ptw6g3c9q0xy6zf"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1cp02hkhu2nq7zznz04shwfvh9hdsp3y5334n6t"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1uf6gyusnqzluacssjjdcjt2yme6wvx23ac3hpw",
+      "liquidity_token": "terra1dwnm3mxgp6svmtng5shfkc52m8d0xsagdx6z37"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1czqey2sj9h2w625ez5kefp6j7d5s08e7lj2yhd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1q9mgca3xh5ka3jtsunjsdy5vjjwaykkynx00ld",
+      "liquidity_token": "terra1qs8frq6vn59u4hv6l7k0rvf8m5xd4n46n0vzwa"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1cyaj8agnyzqtw2k5095ysxxgjpgqptyam283dj"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1kluzznl8srzx3ssxqw5las5ym9rwqtnrgcl5wu",
+      "liquidity_token": "terra1u7v3aqt6uv2y60kwur5zk3sxpcjn609s4xyzx6"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1cx8rey3xpd7e7t6pkywvq6n9y98yq3wlfashpm"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1k26svtwssqveu7huj9mpgeyg58p5d836w2wn50",
+      "liquidity_token": "terra1rfenv23tqqqe84lq49mdsq5t3erh26txwl4nlv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1cxvsl5qdvctc537a8q9ynv0seu4r5ceacptwx0"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1jhvqagr7mqf0nn749et3qz9nc9rfehq6n8xgv2",
+      "liquidity_token": "terra1w4kqk5dxef3f6mlc6rcx35csyc4qk5axd0g827"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1cxusd4uhgpgk2sp99rexrcknpn08anak3v9tz7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1fx82cs3ttpcnd9wg32a70ajkfturmedrgup2vv",
+      "liquidity_token": "terra15q2dvy9ex5k3nl7dsay83sf76t2ug8zend39em"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1cxaky6tfw4j0xqx8ezxw60cukmkewpx70kr9du"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1farlsg7xvnj55ttp7y8t39t9e252fusuvqhm85",
+      "liquidity_token": "terra1hq2t2lgg6frwpr9sycwc5cyqqdlv7pam5qehe7"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1cf9ey4pm9ugeeehat50gadlze9s0mvluxws2c2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1llxwfv4e2mt2fgh5p58lcq9sztrpegmwy6hje9",
+      "liquidity_token": "terra1rrpl6x4yl7jumycjnac98x9hply4zf7q92s5ne"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1cf22rqajmvzpaxr703p0gffs0ejngmvurenjxw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1rn2nz4zrklm60cl9nsdx43x48084aw2te9l3as",
+      "liquidity_token": "terra1m88fkkq4v8zyc7gr5jj5egxk79p7m9mv4eyyjq"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ctfsa4qfanzmz4my78m3u4r9k5qr9gpua9f6hj"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1p6nzgyy7gq9hw54errcyrnjkf7p4expcsnmxz3",
+      "liquidity_token": "terra1wd25umnrgnfydwd7k7m364ykk79r76tclm5v4n"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1cvdaetw5ljrtkxax8z0pgpdyhhhln3saxl8xsg"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1k2ez4u7fnmwv30gysa2rhj4gs4pkngatnl6vxw",
+      "liquidity_token": "terra1ka9qplck0h0kj2jxmnagt8vh64c5qczwkwp0hx"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1cvsfc32dkdvmla6urrscrtfceztecj0u5tvlvz"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1gqqc9f89a92h75m3hqt4c4hpc8466a5a8z4xt6",
+      "liquidity_token": "terra1dxu9d263z3rxdn3s72uswtszjewx573sh4mq9r"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1cwretz2zmeqe2uhq4fuk2mrp4ptuvsct890c6f"
+          }
+        }
+      ],
+      "contract_addr": "terra1nlrtp53mpvlged7pp537avj8uf59j3s0qlwrga",
+      "liquidity_token": "terra16ejgdv4scnaedcjrser8lc73w2gerggx2cqv5c"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1c00vskhyzdv0z63z2tyetzx2qma67n2z3vzyn0"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1p0sjx8kg9zeuefzwu0ac9ftemrr0usdyypsnty",
+      "liquidity_token": "terra1t5wjlrfzl4nc9v8nh40xla3ketfaw94ycxg7ln"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1c0awzlg4ujlt0c2prwtukqeapg2m4qty5fdgs2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1hpslekgztdgykswwhgu7udnqkqudvjdqpns605",
+      "liquidity_token": "terra1j0j79nurur9fhqf5hrl8uav75pqmrt0t06a4ap"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1csk6tc7pdmpr782w527hwhez6gfv632tyf72cp"
+          }
+        }
+      ],
+      "contract_addr": "terra1dkc8075nv34k2fu6xn6wcgrqlewup2qtkr4ymu",
+      "liquidity_token": "terra16j09nh806vaql0wujw8ktmvdj7ph8h09ltjs2r"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1cjf3m2zsx4lu6c0edhfcvp0v4hps6gfr79hyc4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1583mexe3t5gwfjf97paz3r8m23dxw9gjqa2ap6",
+      "liquidity_token": "terra1cvnn7tz7fuxx8u8ym8gdfa7dp2jwv6e3le9ame"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1cnsxjj0378qwu3p5vmrja6j9f84gepvt6r62rw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1kg52fgp0e45nt0wjlg8v25zn4v3gkmatz5xk3g",
+      "liquidity_token": "terra174gmmzaxtrxq6z0tamu2lcekjkjy4vwhvxn93y"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1c5p65p6q6ekfav0k72h5ez23mpntve5am07mpr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra14fgsnt4y6x7npwnnpq7nepk85fzz59vqn562v2",
+      "liquidity_token": "terra1q03qkg493g267tyympe6qx5l5v4de20uwupnn4"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1c5fr3wdf2trj3dkxcckhmzzxlnnpepqn8cu8f8"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra134mvek3w6tp9rzgdklv9pndpdkc2gqvf24um3l",
+      "liquidity_token": "terra1epjldscwcyn3nerwmnf0qnfk8rue7pc73v6u20"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1c5wn5quxclujf8n38cu0sh2r4hq697lpc9385g"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1vnrd37f7cjwgu9zgn7whqcjjuclhhd38qrnqlw",
+      "liquidity_token": "terra1e92r33fhkft6p8fyamwu3zp300t5l35cjxf5tf"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ckrsweg4dtg47qv55ecayntlax3j8ja956nq2l"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1h4mjl52nsy6y04r9snxe23fzdx85vzvpcnu6lz",
+      "liquidity_token": "terra16v0aunfk0tqswrldmyczz8aymwe9r279kknheq"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ckvmptla24qm80yrwkxluhptee4y8h3gemwkw7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1qjus04wsfvxgg0k5k4hjdr20ttlcxewq2lu7vk",
+      "liquidity_token": "terra183pmt26qpwy4xnpunzmckjydsnyw43hejgaucf"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ckkyhfxnqkumqrvmpl6rnrjzvklephzvsse57z"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1trsmqwdgej32welv329ranjf60edtl0q4qrm7w",
+      "liquidity_token": "terra147kcqfp5kw9m5axds4ulz0h9z4wcc9uga7yfsh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ch852sflpmw500y9jzvkpspzw8ej2jf5934g2n"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1fcr6s373mxsw000z5xv9zftmpz2uvc4u0x3dxk",
+      "liquidity_token": "terra166h9t9xrsy0wq8t7hpdjx52eecze4gcussgr44"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1cczv3ck2r909w64n9rdqs3gh5gsmwumh4utz49"
+          }
+        }
+      ],
+      "contract_addr": "terra1he8as5az55glkg7rye69ujsgl8f8gs3khjxwm2",
+      "liquidity_token": "terra1xxracarga8mf8yadf8s25hekr4kd92l3wr35vm"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1cc3enj9qgchlrj34cnzhwuclc4vl2z3jl7tkqg"
+          }
+        }
+      ],
+      "contract_addr": "terra1ea9js3y4l7vy0h46k4e5r5ykkk08zc3fx7v4t8",
+      "liquidity_token": "terra1fc5a5gsxatjey9syq93c2n3xq90n06t60nkj6l"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1cetg5wruw2wsdjp7j46rj44xdel00z006e9yg8"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1runncker37zx0wlp43xchzep33udsn6yje3rt3",
+      "liquidity_token": "terra1zn5ycnftj4lplwwtjrt6jtvqtqwc2xl0ypyegs"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ce0z2295uajnvxltll75zuvh5mvecczy3fmlzj"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1cr5uef9rrl74xcw9vjsqklud2dstdfr4xj7hqm",
+      "liquidity_token": "terra1my49papxtmataag9arh9wdrqyyuqyjfw7cc44v"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1c6jwuklh3262naafvnlw8llvns9856uvc50z95"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra15587sd3nkaqhlve76nxxhp6a5ep6qejh4lnnca",
+      "liquidity_token": "terra1tpx744z60ysm4ntrpk84whqp9tunmrgzm6utcf"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1cuku0vggplpgfxegdrenp302km26symjk4xxaf"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ylwwchhdvck0n07sks7703xzke7vk2yudu3s7d",
+      "liquidity_token": "terra1et5tavdywdx5ug6ywph9uhnwnkc70zg8e26x0l"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1cu7zc3q8089cuu4z5ed5nl4c9w59qqhs2mmfyy"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1m7n5p8e0mkh370mfp0e93jfk7uc34gxxxqegwn",
+      "liquidity_token": "terra1srwc8xh9d5zx700n7n7unq4eww620vw384pwvg"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1clqsjgv98sa2ewwlmyt3pv4uuzz68u45w9pkyw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1htymlk5xlkzezmd6sy3rmucvhgdcglv5e8jzay",
+      "liquidity_token": "terra13k9lu3kcvee27lw66fw075t9jvza9xjyhyaz0z"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1cl7whtrqmz5ldr553q69qahck8xvk80fm33qjx"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ycp5lnn0qu4sq4wq7k63zax9f05852xt9nu3yc",
+      "liquidity_token": "terra1l0wqwge0vtfmukx028pluxsr7ee2vk8gl5mlxr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1epzqhvam83e7lfqtdmgzatlvlzwu23x8kd4t4v"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra18573lxn0gjcs3fh2dc6qfv7l3afrws2k2dk2zz",
+      "liquidity_token": "terra1asqt56e65cw3dmszq47ru7vzrkua6spg9au4mt"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1epz3d7rmltreyt6chgnuv28cy8e0d3yad75xh8"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1x67kglh8uxc5rq4z0dsrv4az0rkfgs6k42fu06",
+      "liquidity_token": "terra1vz850g76xvryz4jhpf2juamv40yey0ugh0pyjf"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ep337j8q9xm7t9ypqugr4yhgnvf0jgyjga50tv"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1mwsw7mzxqdv33naqg50quz9ataxfveur7u48aj",
+      "liquidity_token": "terra1sdlk96gvztayg9yayxksaghrkwv5hsz3psu3xn"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ez8x6k2rru42w3z8lnfkzjs778rllmq6xhgf7a"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra15vy6lhftmg8jnhnsnyazxl44fkutx9yawemeq4",
+      "liquidity_token": "terra1u9nnlnvlqfgz04hvu7w2nqah034m0qjukfvrx2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ez46kxtulsdv07538fh5ra5xj8l68mu8eg24vr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1pn20mcwnmeyxf68vpt3cyel3n57qm9mp289jta",
+      "liquidity_token": "terra1t4xype7nzjxrzttuwuyh9sglwaaeszr8l78u6e"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1ezkr298e3lef6hh5pzmvrtw0qd0kc6u7dgl5rc"
+          }
+        }
+      ],
+      "contract_addr": "terra1vqc0pcdz97llaglpf7gfjtykhxy5r00uex0hnz",
+      "liquidity_token": "terra12qzdpl39xj79ra7s8d5l9tvrqmwk4924hphlvz"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1e9g5cltcufzzu3056nlz4f6jmkruagwukyqd4r"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1acs30twep2y5wt6eremc58wtpszw4drrnxmjj3",
+      "liquidity_token": "terra1uhq4x4payyasa8dw7tsgvgeghxzh3s7xwa3aqn"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1exgprpvwmn9we9xfxlqzchfqd533wtnafhg0w4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1q0vldkwqgc2y2crhrcsdw2pacdt8nnrgvzcsf6",
+      "liquidity_token": "terra12qz82rul3ukhgaw06n2gv32gehermzu4zd8pam"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1extnklxgx3sylp25zplvxsfarmvh3r4k6grskj"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra13lnw7ytlt0cjtjtakgewfzydq3nmx7n9q60gs8",
+      "liquidity_token": "terra1ygp3he69u96xzy09krfa5rkpyk3mjcmrl4dp4r"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ex5age9gqd5em86wg8hu0ak5wrqez9yufvlrat"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1vzhsu5x9f9sglyq3acm5vq7hv0deemvdneqqw7",
+      "liquidity_token": "terra19q5tcdpmqna8ffvr8tmh9yn9cl8u6v66ewpk0h"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1efjugpjc50d8sha7lr8s48cr7wmsthz94eevcl"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1phq9uxe9sg62gy7xcjs5xnzeqdkmvjwezq8d2j",
+      "liquidity_token": "terra1j0s7sep5wdt6hfac9er29hdxj4kul2u57w55jg"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1efu7hut9pywcgwj74klay9mlzswp542s6fa0zq"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra14572czl65ta5gqhpjfehk47yytdxerpntw2h5w",
+      "liquidity_token": "terra1tpxyhuyfwqe5a44crzf35pvjv66v0eu2j20kpr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1edualxuj7afpm27uxvv38zr4e0zf4r4z6twfyf"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1kwhysskh35wqrsuxyv3c02cenwd05l6pm96pnk",
+      "liquidity_token": "terra1zczk7ccfd2wfetyq8y6gkg0qghntahd5pq5qf7"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ewvul5j47zpsr6dtyt0fup6q3tquqq3cvxpjhp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1j5l4c2n9x5hjrluk2k746jx60hpgycva4kg5g9",
+      "liquidity_token": "terra1fcfl5xa6kwgtmymwgjr2rgq3j2h8q00vy39gs8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ew3yvrg0ejpgvswyw70gcqqp3g2j45d24se5xq"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra152vwut3lhzkwjk80nk50m5upvt9tllap60as0t",
+      "liquidity_token": "terra18p8lm6fsgzdkz9ygaqffdvfjcf020jnqvn03f6"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ewesd6y7dswxd8qdfff7vxl8g2p0dfwpanf5fv"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra10a9jdeled7uev64ugtmc8kzjlg9xv6eeey88xh",
+      "liquidity_token": "terra16qlxlx3h5ty2t2fmdwrh8a35yqngg6hlmv0w56"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1e05lrpp2tl6sfm8p095mgn8hqu9c42f9sn0eh5"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra12vqe3zqn9t7j7k7r3u22mpr3pjq9w3gnmx6pd6",
+      "liquidity_token": "terra1y097nnhjger6l3ds9r96xfdpq7vcdp5yh70n6x"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1esezx70a44cqc4pjq0qt3k7k93ksuvepfksscy"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra15n7vemjsxv7w4wgnwqtzufp6tddmycqsklgqe3",
+      "liquidity_token": "terra1e3t3td7uas3ed0gyu9xcyvmh6gxn6xe96yat8w"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1e3s670y5lns7vlq3gxdcn9rv8mdpydhd89jdwz"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1xzk9vcd53j2eql8zfnds9xfxy6z9c6ran3ld7p",
+      "liquidity_token": "terra1t6c2y90qmphcct2q94m4lscnfxvcyu7hrpnamv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ejmg85y0vgsxv5r3cd4024j732pqnwudl0v2d2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1fydslvtnl4d4dujz5kapslwty6were2aeerd95",
+      "liquidity_token": "terra1q3q8lrucdvs93walj4edxqlaj0lqqyrs2sgk7e"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1enj2np0785hw3vt2gn2yga9y75306g6e9lq799"
+          }
+        }
+      ],
+      "contract_addr": "terra1ldpgn35p9m2ksumh8dksp3edvv4nz9tdj2pwv2",
+      "liquidity_token": "terra18qgqfp2pay886vakll5duudytylazyy9eh89yq"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1e47v67sld3p2pre5skqh05ddld22rwhu30fnwm"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1r786pmp9z6edc0qufxgxxaheh5ag735avkfm30",
+      "liquidity_token": "terra1tsg6xz8n86lz538psktzfca7fe35gp84pn487v"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ehcjwxwf96c278n2ks84zes3ece5fqy78fa749"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1xg660nndl83z5n7j4jd0cnrygs5dndcj30sazn",
+      "liquidity_token": "terra1skhn7p85uyqle4yyxvdvr92d0lj70hvctdu9dw"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1e60jlze35lh05dlqrh2yjv3r8z3gktwchykrq0"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1f27dfgcgx5zpa2f3zd9s79jrjmklwq0l8fa6el",
+      "liquidity_token": "terra1r3hc388xqf83u86ruvhfe3p7pnggz3stf694qc"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1e6lfxnuyqg3wxvczuz0zkmvr40ldvqx26eqk5g"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra17rmhzak7ymvwlwr275neppvxkrr3xl6vj0dczr",
+      "liquidity_token": "terra1004n2l4z26cuvchplkkrkxamx3un7lk702f0xy"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1em52fj74ezgeqp5s6mp96y494s2gkjmtqy46sq"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1x5m76lyeklv2hl50kqlmw5893qawq22k30yw45",
+      "liquidity_token": "terra1gq6ulqmrxnzx8uyrmjmqu4kguqxyy8xwky5mh4"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1e7hzp3tnsswpfcu6gt4wlgfm20lcsqqywhaagu"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1gwd9m3e08m53fnhgv8k9vsjrmvwelhpxr2ww8h",
+      "liquidity_token": "terra1jl875nm4p2z4jgapz6al2h74ug0fpf59n7pfjg"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1elt5czsf7sntku3qafxf7xrjxdx309kkkmc8up"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1vsyw78g3jfn5kelw09tttxfklrhewgtp62tw0a",
+      "liquidity_token": "terra1xm9vcuuyduxy8cc98tuaknnhv5tjv4x5350jvh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1elveensfjwt270xzt8rcpvwmnhawrrqfx5atj4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1fhgksqjyawsym7myq04ddvm0sgxwzqqlw4pp5j",
+      "liquidity_token": "terra1xsv563k2wyuqkwza0mrz6ye8exx4a9r0hdvxs6"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1elkjjsg4vm5u4tnesqcj3dzgvhanzld48lkqv2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra14m9xq2tvculdx22kunc40te7gfhylx0v44qj3r",
+      "liquidity_token": "terra14t4pe3avwql7s3d7euz3jrpsjzrgrl50x4asv0"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra16q2hhuva6u0zakfav0pmrdw2fhjsanvqq9y56t"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1fqr0y0djympq8zfgztev9dj7fpp248pff7860f",
+      "liquidity_token": "terra16800h94m9r3n8alhu2rsxxpxyesh9sylu3jgen"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra16qsk2zwv5fsqd944p28f2dkddr7eq9uzuxeh8h"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1rh6rwrekv3r7ep89lmkysxugsvuaqljmmepx5s",
+      "liquidity_token": "terra1gwkdwvljnj0pud5qk87e0vnuu0a5j3qh30v6g8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra16pj0sful7hl87j8h5qwnv6j4vv76mxj6a6026v"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1k6na35qccghzvdcrmp8djyw9vxklrkxx3vd49p",
+      "liquidity_token": "terra1k0zuu3ljmwqmvaufz0d22d37evsrzju3cz4xru"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra16pektynpxqrs66gk6cgqpwr7rjsudyfzustm6s"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1t228agv0gpw0uryk7j2lcqhcwgylwkgumf2eej",
+      "liquidity_token": "terra14j965wgdyyrkryjem570jh7y7lzgyrs0jp6xud"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra16pem7c3h7renxuxa4jvw8efv4nhrdc3leguzyn"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1cf38v8qumxruarhxfsgnylkymz6935c6qhcrkv",
+      "liquidity_token": "terra1kxddqksg8x8gmdu5l5ceqqyva9ypnzujldkj03"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra16p7wv0m0upx763r5aux6qatzyve44ezdyqpq5m"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1je2lsw0720h2w64ca0559zcav5ltsqcv3230ze",
+      "liquidity_token": "terra1lzqkq68yfgtuu5hkmd38f3tsnw9khgaj7362t6"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra16z32tp6cqx2f7lpr8t4scv8hj9zlljagprxfh7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1rn8stwf23aes786t37je7v8vxe9qwyzshrl9ft",
+      "liquidity_token": "terra12eruh2ggjy2q8wutzsg2ww90nrucxm4hmuzdct"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra16ygrvq7q2zxw7jj3f96racur50w0g7r0mj6e2y"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1m8dlx0g0j00xlxvavh972sk0gja2xn5gxjvtu3",
+      "liquidity_token": "terra10yxksgtaluqt4mdley4umd3fqsgj49wfe5knvg"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra169edevav3pdrtjcx35j6pvzuv54aevewar4nlh"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1u6dhkawjqxn0za9w8kvr7588ng9y73l0vj62fa",
+      "liquidity_token": "terra1q4c0u5wkfagqhrg54huxjxywhf7l8nkdy0zg3e"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra16xtp5rmhx4agcas4cyg3srp6m6gauqagh02v9z"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1hm4gfvl5d65v03wzgvy5lh780dnwk6xtnaeurj",
+      "liquidity_token": "terra10n7l0rxnmwjehufywtvd3lj952rxdt7n8e9skp"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra16x6mn6ulxzg4pgg7gpachkkgrkuac59vl7xgyl"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1x63m5uekv23x5qqyz7r0t2yj07fk2m8ta869en",
+      "liquidity_token": "terra1schvtmd7u2nee4ad8sm6qhgzwv86lv6eypj56z"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra16gx5th8mk5v62xpvgf675xj2vuaf3dg4v75ml5"
+          }
+        }
+      ],
+      "contract_addr": "terra1vjyvxsunxs6dvu5kh08chk69zffcqcntccgpf8",
+      "liquidity_token": "terra1hyt7x6duee8qxhnuyjdkmf5ucg27a2fjl7tdzw"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra16gnk7mpqr84f4mnmqjklpdxxe602dn0fjslwhy"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1qvy5r6r3fyh6rk9j93e9w63z3qu4wlmxemd0kt",
+      "liquidity_token": "terra1z27p3u53z9tfagnpffqe64js9l77w38ywyvefp"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra162k5t3hl204lrwe8xvalh4pv4gdrjvdrjlgxst"
+          }
+        }
+      ],
+      "contract_addr": "terra1dsmz3dfejj47wcxes66gktwqhsvyxe9n2pld0e",
+      "liquidity_token": "terra1cnryfady5636utnsvv9uj429mhnwfqmtr4als0"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra16t8cdhps9sxk7sje2w77fay8lh4se3p4gqjeya"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra19vrx0crmjpkahyhmmtlsgcnzgss32nwgnqudfq",
+      "liquidity_token": "terra1lfffm32qqz3lt4vt36tcslmdayuh2lyvm0yhdp"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra16wggm67a34msdxasg2vergm2pt289y7930wv7d"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1fg8f9s8ltyw59crjde6vrv2chvcprndayk9gt4",
+      "liquidity_token": "terra1w5etcaqzhwe6huwytkwuxzkvlvqx98vgu6z96u"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra160y9666sr9ctqfzk4mu7useh6g6swet8vnl7uz"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1kvg5qyt25nrgkqeuanz0k7cavxg0qxe2lgjh90",
+      "liquidity_token": "terra1k093hrmpy8l930ehgtvc7hrdkja3pnudr7ue5j"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra160hntqlsd7wzyydhzw653lw8puftnwaj327xyd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1tqk8w5zzkv0affe375m7pldgwvx8m496lrhcsx",
+      "liquidity_token": "terra17y23mq28m6df9gghnf0d4tzedrsga2v4k36k56"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra165nd2qmrtszehcfrntlplzern7zl4ahtlhd5t2"
+          }
+        }
+      ],
+      "contract_addr": "terra1vkvmvnmex90wanque26mjvay2mdtf0rz57fm6d",
+      "liquidity_token": "terra1q7m2qsj3nzlz5ng25z5q5w5qcqldclfe3ljup9"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra16hwgds2089kktskluq8dh5ntw7eu5e4q4z6ud4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1v846hwep6tr3wfwe2phu3z5ht9ufm9kwqzn7w3",
+      "liquidity_token": "terra1hz2xxt4saxl79k4p3c9pqutldyqcugwuh8fzpl"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra16hhxhyg5eapesc7yw4j5vymr4sqc87fg89a8pq"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra10es246n270j9eu3xrs6dt3edvtvdfacduggzq0",
+      "liquidity_token": "terra1cmudjcj3ltluu8jsnhj8jska0dwgzcaaepkqtv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra16hhm24fc3wle66m3529n2jctqqsds57wv4c087"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1473vrcpk28pc2smude02a98ft3ff05gqv5xtl9",
+      "liquidity_token": "terra1p3pky64g3jq6s466g8jskszt2k7e07ygt9z8z2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra16ea8pnh3hu69kzqqps5gqw0zdd94hgul9tfnzw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra14rmvvzfs88axcrk0farsdswylj55umpj6kqh79",
+      "liquidity_token": "terra184dw47xvmz29g7aem7evwe55pqhy96xq8fy8rv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra166ep78d3434pyufs6txfkwnm7t3ep303f3phpm"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1a4956lzj4vdvh33dp9wu6g8mlw6npt3ttn233q",
+      "liquidity_token": "terra14adxrkkl7zraxxveu2dp6avt84d24h09wcu639"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra16mvysduudq3ys8vn08c5ts8yx08g5vahjaylq4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra12xwh5s8nxl2tr9lvshtv5ny02g349sdhgca4zs",
+      "liquidity_token": "terra1hqz4rpdymf0vdmmg54r8fzr95uwtq7m7stsqzs"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1677xekxjqc4f3jqut8yr6p29e8h5zfay37et58"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1d6h7dqr20lrtv4zhqntvxpxgwqw694cfvhh4st",
+      "liquidity_token": "terra1ym24m9vg93hgq8hmvc8njquls9sq2x0wqjssvw"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1mqsjugsugfprn3cvgxsrr8akkvdxv2pzc74us7"
+          }
+        }
+      ],
+      "contract_addr": "terra1yl2atgxw422qxahm02p364wtgu7gmeya237pcs",
+      "liquidity_token": "terra1jh2dh4g65hptsrwjv53nhsnkwlw8jdrxaxrca0"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mq6sw9dt57hlpe7ffjm2z3pytr98l4a00lnxp6"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra199cwj22qrsuqnuv4slrmhc3dfydxjh3894tajt",
+      "liquidity_token": "terra1yjvdd73lsjq49v7x80rhe3kyltg27gew5nrls8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mqug8fps3zqsywzrukz5m6shcnj4j4rqna3kzf"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1pd3sdj23u85w3vlrtmrpadud4qmxhppyy6dsyq",
+      "liquidity_token": "terra1rdjzzqdcqasnu4kgk796e3rr9nvrhx5y9xdg7e"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mpq5zkkm39nmjrjg9raknpfrfmcfwv0nh0whvn"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1r9n03pheztcxrfcykwazvxzd0rnvzrdrdwpsf5",
+      "liquidity_token": "terra1gvakrl38c6ygrvzv2srnp738z43xy5prpmy78v"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mz858mn7jeglmzj0ay8z5zy6v78fvv7em9tljz"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1et3se39fd2nmnuygcvls2amujzmv4v6k4xwv69",
+      "liquidity_token": "terra1r52sh4ksk35t4zt6qvpp33l0fu8l4fp0k7j5dj"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1my8t2mhxxv5rzjtzc8cppj8y76hy3apvcntttw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1yv9dr0suw8njr88ls6ya34y2pevq45k5yg0vl0",
+      "liquidity_token": "terra1w3xdh7zpllve9d72anjtr5lkxndshggdw3zdke"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1my0tlq45u0vlpyt2n4qchxkzhzwnxrd2playfq"
+          }
+        }
+      ],
+      "contract_addr": "terra1c74x8j9caymapwg30z3gse2jlxvgkm56uhv6zq",
+      "liquidity_token": "terra1cgfghgpw8u832e9xlrya7pqpj0pyyfpyptwdte"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1m9fuqymdz03umd88guyc79083hd7vppzu74vck"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1fgn8re8qf9am8ymkmaawgspym43en9f8w50f8c",
+      "liquidity_token": "terra10evwunz82kc0wucnwyxnzq35yjygl9huglrlgu"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1m9w3pdjst86dmfdamq5tuu4ny99e89eaavdz06"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1zzqkcp3e5apwdpsnavfrdrf6q0qf4esd556xg0",
+      "liquidity_token": "terra1tk7a0hcs3yehfzrscjhw824jq52ndvsv07d7zk"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1m97d9028kdz002wkq23kp329w68yun7p0x6vlh"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1cxcxfa5hd60t8t8rphzgpwunwh3dxplzm0xpwj",
+      "liquidity_token": "terra1r099m6j4unzjxv77vxnt05hrszphpm69f5x2rs"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1m86rdykfvtwucrd0y0gzlel7wpcdryctak5wyl"
+          }
+        }
+      ],
+      "contract_addr": "terra1s846ywp9gdkjfmk48cs8pd0phtsnn842zsgsa5",
+      "liquidity_token": "terra1dkpn37uh5f5j3u9rjp6ynpekm5kzd7ysfffqwq"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mgyht7c5usg40gqt57zmcd93cdwt49eehysm9p"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1et63aq9nclyehc6j05uv5j3nvm8sqfey99u9g2",
+      "liquidity_token": "terra1qn4mpmcjwky96v0cqk0ru8azrk36ghasn8raue"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mfwgs4aglpetsyy4y55k9g9hsnp5xtcykknldk"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1wzuyqt38l99tdxzttx9grktr3grllgsqe02dz8",
+      "liquidity_token": "terra14936pd4ptv3hkh2280qm3fx940srjvvx6gv8sl"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mfek3m9s0sazd40kjraw5qv3963t5n3gwk408u"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1emetwzv9g6pc0gp5ghj7h9wyvwm902wtxj76d4",
+      "liquidity_token": "terra19kadah8p79e4m766e3q869jv5f67s60qfxznmp"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1m2ar36pnymh6h4n0p7l2w4uxswc70e9auyvxh6"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra14pq5tphkfpd2wphq47g7mrwmvt7x63nskmkkrc",
+      "liquidity_token": "terra1rxft4gfmy7s5suhmn7jpu65qmct8nps09ur8ds"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mt957lrc2z93f5utk509zma6pgtceaq6tqedc6"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1jftv4fh6wyxx8rnfw343vyl5ehcpn47syn8yzh",
+      "liquidity_token": "terra1k597uc4rzvlgmel8xkz434xdw0tsfmt7es0pwy"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mt2ytlrxhvd5c4d4fshxxs3zcus3fkdmuv4mk2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1gpc8f9t9fhehjqlhxlq7aug4vgpw0rfrzsgwd0",
+      "liquidity_token": "terra1q3qrs5q54m0u8ws8vtluwyfppt9ummqp52wftn"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mtm6l7xdmpuelf2q74sq58d2e5gwm72d42algk"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1n5nzqdktzh6j935y09244rghn6zl3ga6h8ktdk",
+      "liquidity_token": "terra1t32vjs5l5f5452kq78wvtaest5qkhr37vymcfa"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mvgs32slrxy29qhfmd2vn7y6l8knmtw396uxde"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1k5rnwftj26qlw6q746nv59jvg964zjr58ddsq4",
+      "liquidity_token": "terra1za869t75aa4tjatrtc8sqxfphymmdj3k56w7fg"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1z6tp0ruxvynsx5r9mmcc2wcezz9ey9pmrw5r8g",
+      "liquidity_token": "terra14ffp0waxcck733a9jfd58d86h9rac2chf5xhev"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1m09t5cs473tvl7lsregj024d3dwg65su6ufpfh"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1pyc4z680nrvd00xnqh24dtvap2840w0a44x7ns",
+      "liquidity_token": "terra1udkgg8n4ynny7njj7fra88lkmjw8f3ggy0crdu"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1m3tdguf59xq3pa2twk5fjte5g6szj5y9x5npy7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1vayuttjw6z4hk5r734z9qatgs8vp6r5a2t043p",
+      "liquidity_token": "terra1p4pfnpsv8ly4mgzsmegz52kgjq8gp64almryky"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mkw8x32086w0emr0wkprrns9j0c82nnxusn7dw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1yje5awrwutgx5p4mg3e8vtpnttav5f6y9m3rgh",
+      "liquidity_token": "terra1h3a58p3haxgt95eq8fwkptwscyppq0laque0f3"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mh7nlhzvvesgc4whcx7dg2nhj3p0dhl9fwrexu"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1tq5tpycg8f5ndchv5un89e6cxel9udkwquj5z7",
+      "liquidity_token": "terra1kjllqt9yfp6zck7pm4ddrwcy0uft3kf7pdrn2t"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mely4fttd94g5kgjmz05dmclgdahq45xnv5n22"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1dmne5d8e4ej5ahy4jrrjuytju6djnjed8twxnl",
+      "liquidity_token": "terra15gn2ksne0vaf2uz24728pshxtvqud7p0m8gmvp"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1m6j6j9gw728n82k78s0j9kq8l5p6ne0xcc820p"
+          }
+        }
+      ],
+      "contract_addr": "terra17eakdtane6d2y7y6v0s79drq7gnhzqan48kxw7",
+      "liquidity_token": "terra1azk43zydh3sdxelg3h4csv4a4uef7fmjy0hu20"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1m6myw86l5zgw3z58z6rynr8zxaexprfc3m3357"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1nazuk5vy7u5nwdnlxefcevy75yyr9z4mejq0a9",
+      "liquidity_token": "terra1mw45v6n4n3r4ekcqn73t9wmed9xv45sx526ty3"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ma4frxgvc974je0xsxrzpa52j34h9swlww2yed"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra190r2p96klarzvdssdg77r6sd4nfutjra7wwz8d",
+      "liquidity_token": "terra1hl09j27s27407wkct646lqnxg3qskpl2ehuvn9"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ml4r2ry9pf9evmahn0nh5nzjzntf63wzmnull3"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra16r4zqs04jzyrert9udg2s8g4qnrqy9syw4kxhp",
+      "liquidity_token": "terra1gjasf5qq2jlmzle066tylul3d0s7vd6g667p7e"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mlhehkx4rgp357jmxhqepy0nr4tjetkje9t686"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1gyrp3pnw34wy0ptyjehfw6akwd9h4ed6kmxmev",
+      "liquidity_token": "terra1v29xuc4he907gkpc3zmrhqhuxcvy3jhfy50wue"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1u9hgxjw5k0aje9xjf0ejfu6uwmamc2k8ylzd7l"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1mp40g7sneygtnxdm2ncxmjq45pgut2hryxck3a",
+      "liquidity_token": "terra1q7n7hzd9dsmakmzjql2mdg5gfrnx42a9hj8665"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1uxqd9gmtxz45yq53t2m9vrs74twwfrjmrqmdjd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra124vedvwx3nrwepzc2kmdhuhqn7j6zxq0jq2p2h",
+      "liquidity_token": "terra1x4c3g8z9p3ae3sdc4zkts4d253ws6nsyczckzt"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1uf95uwdtg7rp734pmadujg2ukmuc88fph2925c"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra13kqma6mk7ylcvg8u4qmfcwyw3wfytdgwwszmqc",
+      "liquidity_token": "terra1p9gjvxkdefm98aghrv98nj5g3j8vp2qq22kg6m"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ufxgdde0fkmmc7mvmkuaxps9raua78r7f0vm3x"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra16u0mmxkx0tm7ll5674dqazj0rznft6jfeku0ve",
+      "liquidity_token": "terra1cxefedc77znngtrw5lfrf87kk6u7wus6mrf4ly"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ufsyu3ddskufc7nel5p4lyrzhv8qdddg3tl550"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1rxwlts8xqulfrmx66whcknczmqjh05hdhwm4zj",
+      "liquidity_token": "terra1vhw9kpcshkr2kfrjke3pgp5sr5vsxdu2cjrf43"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ufhsnrefjazjtyjh2mwxcnsrejmvqvdrhevph2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1yxgrh88ghn5ldwkragg920ru0v4tyeq3qxxcap",
+      "liquidity_token": "terra1n33e2tarnjr4ptz7stvf8yag50xeq2hsucvzfw"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1u2tj2wy6gc8gw9g507a66796ej2csewp9asznk"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1klucl4s6jusuvrxag9hyay90cq4h80mkjhkw9j",
+      "liquidity_token": "terra1m28rcqy4fhhu9twwpuv6fdajwmfwlm02lwlzw2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1u2k0nkenw0p25ljsr4ksh7rxm65y466vkdewwj"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1uyvksaz9xpgxpqnq8vz9vzg59up8mlhx3463tf",
+      "liquidity_token": "terra1wlssklspcq2arkl0vqgha5rg2sz8jfufvmjj82"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1uv3298xevlfdcjthfv4me7tn7gjxd3drv6ejvt"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra14v7q4ujj95wx0leltqsxdxy97gzgw4g4q9656s",
+      "liquidity_token": "terra1fj8zwe73graryv3jlmgtt8a74agw849jrl3tfg"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1udknntc8sjm4ntxezhlqe6p9atct00r296aw95"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra14fkcayxsf0xg4dwvn7xgtsyhzff97zckpzlzhv",
+      "liquidity_token": "terra1ce4u5ecla5klh9a68mjugq2aj2zqffrar4vzwh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1uwsnmc4fpalrv3xgvf0aedx8tfn22xcyrx4467"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra16c42gghky97m3g5nj80h3528m3l7m099xjlh0h",
+      "liquidity_token": "terra19unte8ca7uu34q5e0lktrd6esm7wq9j3cmfl4r"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1u02kfjra4q9272p0ckq8yjtfc5qq6584amvrnm"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ps2j3kp3gwjx56fsahnnkmzv2y9e597gqkulfn",
+      "liquidity_token": "terra19e0lhr0645336tuhdv5adj4cqgsphrp6p9mjya"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1u02lqdhuhdfwph8wsl9yx9r0jupfdsd22q60tc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1vn3anrcp54lep043kqwvk9433r0a60xj2tlgpu",
+      "liquidity_token": "terra1h44ahd05f63yamv553rqa0qzmfyp86j56smv4p"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ustvnmngueq0p4jd7gfnutgvdc6ujpsjhsjd02"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1upuslwv5twc8l7hrwlka4wju9z97q8ju63a6jt",
+      "liquidity_token": "terra13m7t5z9zvx2phtpa0k6lxht3qtjjhj68u0t0jz"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1u3cykdenv7z3hveg6vfc0w23gfhwkdktftka9a"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1f562s8g3y45cqxqn4qftvwcwxh2rc3v68ug2cx",
+      "liquidity_token": "terra1uyar5ylq5r4ctw490jsypuu9gufyc702638kn8"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1u43zu5amjlsgty5j64445fr9yglhm53m576ugh"
+          }
+        }
+      ],
+      "contract_addr": "terra1u3pknaazmmudfwxsclcfg3zy74s3zd3anc5m52",
+      "liquidity_token": "terra1mv3pgkzs4krcennqj442jscg6jv84cejrs50n2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ukk89gn25p7xseqc4s4d45yarjlwychrwx7umv"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1qp6jp2sfsv8gmdh2tu33w904qqym394fzkxnxd",
+      "liquidity_token": "terra13ek9x87hp9t3gf5ltchzhl3xuhhakm26jyj4vz"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1uhwhrypcnucvcc2ayt92mlky2xtatslrn7tte4"
+          }
+        }
+      ],
+      "contract_addr": "terra1pc0r79hmaznqh7tnsmzmh9zsl5y87t02zz2fmr",
+      "liquidity_token": "terra1y6x3mh07l8xdpxap7xw2u5pclrenjaulpcfh36"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1uc4fwlh2wn59qqk8y7ld0vxc9hvsufaa5gv5z8"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1pgf2ntzk2gh2lar6zh0yjwchmrtym8zfzp296y",
+      "liquidity_token": "terra12xvfjxzqw22n55ck4x2vqegev2qgf32vu3j9vc"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1ucme9gd7wr7lx0sysnydhdhaqtrg4403nrqm0l"
+          }
+        }
+      ],
+      "contract_addr": "terra14t6yzxt5vhx4dyjknzj78tge6j8385awnczxpg",
+      "liquidity_token": "terra13hf5j4de47zx42ak2sleh4wkyvt0hsz2dfl2zl"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ua6saapgern9jpmklkvxxq4l06nal2cwd0003t"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1fvzjp7p8qy0l332qy8rpljcufmsqdxjyvckney",
+      "liquidity_token": "terra1dvkjth7zak3f5kvn7l8vfp9n0cu8dtjnjhdql6"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1u72jtyujxu8dmpxedrrtmt5tekn0usf09r2a9h"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra17y0ujwl2far0rtm5qqjlx6ghtndcpyzqulur3e",
+      "liquidity_token": "terra14r3jnk537uwkgvuwg227jj3z50xcetwtjcj7sh"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1u73yaveltzmn69vmnqh2nflruk6c2xj2ak4ldk"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1f4gxqu4a093neyv9ak59hghywv0avrp32cmdtt",
+      "liquidity_token": "terra1azedp3s7x8ujquct059s93c0jf4n7wl0mzxwp4"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ulzl6vfexrk39vaje0qryarzlq2ahy80cdl4fz"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1qzlnxa9mdnxkhs6wwf0xvx0hxqday87dgxn9yq",
+      "liquidity_token": "terra1mfs0xeakt59wemvwyelmh80025a3m06jfylx2e"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ult8nl3u83p7vdjdehtjfn9ylkm6u606nmdry3"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ynlz3aw0fl7g5anwsnf38sg6sej6dplpzpuwv9",
+      "liquidity_token": "terra1paw385320c9cn2ljnmcac9l2d2zz24fegltm8c"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1aqfqmal9vllc75dhqplx3zdfsyfpmx9c0q9rud"
+          }
+        }
+      ],
+      "contract_addr": "terra19uem3h0laypj9w0u64gaz782wqe0s909uaarkp",
+      "liquidity_token": "terra1m4q5lr2s3j5eylf2jq06d8vw0au3trgdadezfc"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ayxfyasd2ursa5gt5zgzgfywsw999dz4yykjn7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra17gh85ddky3gqyzg5lh8xry0d4ee497wju497m3",
+      "liquidity_token": "terra15q4ypjhljlfkfmz86xddkd6y0vnwyh03mj6q6p"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1aydw57mpa6jg5n3xnrau9g7mftd3ch6fh7qzal"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1nx3rggxrpv0yekes85kg3fa7v73qgphst6v5gj",
+      "liquidity_token": "terra15hus6hg88440lypz37a8u90t8twdjmwnp92yfn"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1ay3729yle6u6wxj3wcm8racn50a2yq5r8vxvkx"
+          }
+        }
+      ],
+      "contract_addr": "terra12zwtkdu6qhs4f8jw9zvdgrwl24mwag5kuh7gus",
+      "liquidity_token": "terra1283mf36gl6zks6yxr50mc5cvzvg26qg50mq74s"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1a95wwge5ut59aet6wx9m5ukq0alnxj0waf4sgl"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1x6sxgww5nrclca4thc6f7m35fyk5mgepe63pxh",
+      "liquidity_token": "terra1vx6h7nmljrcxfrd4n87vvlfjx37qyexzccenm5"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1ax3mp4cs78xkryavm733s2m4exsv72kd9c4c5g"
+          }
+        }
+      ],
+      "contract_addr": "terra18j6lacah32zsxfmx8uevzq93ryzx5qlt3r3jk5",
+      "liquidity_token": "terra19rc9ttpt80k7mgmy8e0t9e3r6q4m5mwvwyjwul"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1a8k3jyv3wf6k3zngza5h6srrxcckdf7zv90p6u"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1emg7lr0fxyqxkytdk7seupa4lvgda2frxjluz6",
+      "liquidity_token": "terra1drarcarn8y5hzw0hkjcpa9nhefpq8gqdfeq3rr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1a8an0aqzjghcukqrdgnkt3ygzhmaaqza03mc3h"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1x2jjzqv55f3gvrh8ytejkt998p8vnhn0gcg26w",
+      "liquidity_token": "terra1vxplg3wdnz4xtqu8srfvsgh2ws7nt63qx77np9"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1agkfm4zumwkkudpj0882xaex7fne3rume0775y"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1eyyqh5a5w6sx36q0dgdewmnvxkud8yap2u2xp3",
+      "liquidity_token": "terra1fl4qcp5a3vs5unz3f3kgjwr7rxvq3g393jrk5v"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1afgfjpny09lvxl06llcy7hfu0m2epfddzn0f75"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra10zaw5l7aa8hcgfml5eugkmg3dgvrxhnxnsrtdr",
+      "liquidity_token": "terra1c6q6u65steuen92250ev86rvm25yay3lx6008z"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1aft2zjfhmetslqvy0jg6d0ywhf9r5zf5zqratc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1vq8ygvc47qn277pke8k3jvuyslh3ljtqkxka3m",
+      "liquidity_token": "terra1mc4tyswf0msvm2358x7eyrlswn54n6x973v60a"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1a2f4pxdqd98qclaeafdqxlc3dvnt3wqedx3l77"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1nugs0qddjw9eznndg497ukt04cq0cxurql52qk",
+      "liquidity_token": "terra1fe089wx8cnm3pfk9am2rmexrwu0vkp5skzphnm"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1atpd4n3u6tl9ttqeqdwk303lcj2j7u8tpnx53p"
+          }
+        }
+      ],
+      "contract_addr": "terra1xk2dnaqynl297f6r2yp5xp83yd5k8kk3mv8s7r",
+      "liquidity_token": "terra1mywz0a0fzzv69fxct84jj2777t2err6sn6pyu6"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1atcayac92cwn9x6fcpxnjzycvmkkhwsk53tg29"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra14qtsl0gqwnlz5z72cl9yc52lt8q464zhsx08tq",
+      "liquidity_token": "terra1fpaehunc4mdk0vmkn4g32epcf7yl523nujrjsw"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1atagmw0ssv6wlgmrjjdaa22p7h4wmsy33eljgw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra13ha9p29fpj4cckj6jr3m743d9h9v9nv3xcmded",
+      "liquidity_token": "terra1mlkw7ja6gdy4nrrlv8xxtfxh8guuwzz7w38p46"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1av9tfs7k5gfuzm04e7p0d4ezrc53vq9mn3m08z"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1nfkhe4vy2844352ev350ldpccw06ud88qptxd6",
+      "liquidity_token": "terra18ypccdtr2c57zd2q8l6fu0fw932ewawlx25pzk"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1av86k92kuj9jem24pmrv3j6xkrltr2xluz4665"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra18u4fdqhlsxraltxj9xq6rdf5h8ttp6quwtqhxa",
+      "liquidity_token": "terra1arxzxdelkjpz6fgh37vszpw23qpsncy4rfatsx"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1a07n2cp4wd49ezxdgm9xgtfrnpmxfcdp4yrdnv"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1yfpksrlypf5c3xc9ktsup9mtxw24r6sshck3g0",
+      "liquidity_token": "terra16cdhrjh90ptzsdfajklfa9gcf4tlqkrgnqmsej"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1asq6hza8spaeghqt4k7fnj4m7nfaag07ljdqz7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1zpu7lgsfw3l4q782wdjskn8t6nn6rwlpq3d6j6",
+      "liquidity_token": "terra1f3wqhqe7sad8f8vjvsjjv0na3w2xcc639njxjm"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1aszsg6mzlzkydqtm46u42mf8zxur9m4ydh9vrr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1947q02rc7dcynzgywduaudwjmr9nucjzkd7l6e",
+      "liquidity_token": "terra1sedpm809sp8spmk7svhnxqdqyu0tzxn6h0zltn"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1a59ns8fnk04sj982ymkvx9ygscmf4jjtm4sltg"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra15rl2agmgqjwlx3qqqe9rfjcvs3lxl2e3srzwda",
+      "liquidity_token": "terra1yat0hf40dwwery3p060tvdh8glf7a8mza2rrmp"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1a54dqqqh4qlz70m43n3a0vqeu2dv5tkz6t2zan"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra17g2lqz62y4p40hp6f0caup374m7v0uptw38vev",
+      "liquidity_token": "terra1chlp9faqplsyc5y886trcffyzxhnsvuvj9qv5k"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1akwn8y34upderjyw07hgepunte8mza00vafzfd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1pgla9506h2ed9p93y6ryvxgj5admukssrcedwx",
+      "liquidity_token": "terra108gn88qjjm0zmd0sjg39dwnksq6j2ehmp6pf27"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ahygklrmejad3mmeugsd0m5lczv9jl8hjepp6r"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1her3umx232n5jyrmlksxwe47wrhk47zvfzkged",
+      "liquidity_token": "terra1a3sep32fk959cwjam9u927qm5tl2rzyrdrljw6"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1amehwqrzcdrwmwdz9apz9mmctckez66ns67k5s"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra100k5zacnuzl0ksxrn6lclmdl0u7w6l8qalcn6e",
+      "liquidity_token": "terra1yg09m7lcj739wvr3ns6d67znhyp4jexvpx2vkg"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1au93h9ek7flj6f6gar0m8g6ee0nyahd5a6j9uf"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1s4efg35dx3h87v2q5juaeflv59emrejfywh3gz",
+      "liquidity_token": "terra1x6uwp7llj5r0f3ue0k3vxqkv9rjxgvfrs4pxnw"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1aaqzva7adgwtzfkt9nmrmuvkg9s6lmsgtkg3jd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra198q4sqvt4yczlxxs9cjtktqdy7tzthz8vhz6xq",
+      "liquidity_token": "terra1ngyawdzf02gktxmat3m5gletfq65c9twkeyf73"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1aa9kg8crxjq86ts54d4un6ku5skec9e98t6tau"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1vm6whnkl54g5zy82533r34fhuaqp58f9kn826c",
+      "liquidity_token": "terra1g80la29wu6pnme68wj69sskcnnqg7zha69fej4"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1aa00lpfexyycedfg5k2p60l9djcmw0ue5l8fhc"
+          }
+        }
+      ],
+      "contract_addr": "terra14hklnm2ssaexjwkcfhyyyzvpmhpwx6x6lpy39s",
+      "liquidity_token": "terra1jqqegd35rg2gjde54adpj3t6ecu0khfeaarzy9"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1aas795lj3dt6qrsp8n38fr39ypt43p6czgz3ra"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1v8lsm7hmkdwrgcxtlv3ltzvpup0ez6dr8nxdl6",
+      "liquidity_token": "terra12a5st8kc8hlypk7lhe8tquljcs4z89shah98ce"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1aa7upykmmqqc63l924l5qfap8mrmx5rfdm0v55"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1y8mwewf406ayd8uquekh5a7yljpfdcjekkle9c",
+      "liquidity_token": "terra1j7d46fh3p3pka4rkfc6mnwwntqur2sq05ddyx6"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1a7ye2splpfzyenu0yrdu8t83uzgusx2malkc7u"
+          }
+        }
+      ],
+      "contract_addr": "terra1fxn30f9j9a2slvlxxxk6gyjlqnznhprh0wu0mv",
+      "liquidity_token": "terra1wy2cweqqxf0w23g3c9t8e8n5wukcf24fujfhpt"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17qy9f5h35504jxexwprsf6gtj009d3gjcml5pp"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1238lf7cayjp4f4fxle5v87eat6vekqn2zfh9w2",
+      "liquidity_token": "terra1m6hs2jffl6w3qtetxkuaelnasg0jhwg00yz22p"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17qfuwapug8scgw5satxs4n95u3taw6fe8hdgty"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1dqz4zx0uecwjqafzyej7pzyhhqse2agq767al2",
+      "liquidity_token": "terra15pqvt8z4vd3kn3y7d7pjla76a3hh7c9xxhjkwy"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra17qkws34rpkzp5clc86xkyal8235lugj38dhk5v"
+          }
+        }
+      ],
+      "contract_addr": "terra1hh5c3yuq9q2rnvndkdqp0nxr3yh7hwkfsnuwwl",
+      "liquidity_token": "terra1x9rpp68cesaf9mavgyy037pqpdpvp2mllt8yg3"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17pv5zcuddm96m0nuanw25u4p8nkc9460hz0sy4"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1wkcrktmkp3wfvwqvydlx0a3g4tywjktke4pva6",
+      "liquidity_token": "terra1hyc2qcu25cgg2fm75zee79a8au038mevhgaaql"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17pc8eq0u35yslg7zulkqzc2mvxryfj3hw7nmsr"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra10ups2qsazavszk2ml0ed52rqdstuwr2qtuxdjd",
+      "liquidity_token": "terra170c9286vqw9vddvfg4pemue5nxx6vdswxyccmx"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17zhwz3s95dwcw373eklrscvn4jr6f7sd7qpk7y"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra147adm7pj9nzsdulnkqv2pnslp2en2dnpvs24qq",
+      "liquidity_token": "terra102l9yp0zpzrgse96mwgnfyc0rmunpyzrxg7999"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17zeqmepm87d9g4dujjsctqjrfhz4xjkup26t03"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1c5khrjsj0q9l2pyt75cw7hrwst7xyr9vegutkv",
+      "liquidity_token": "terra1hd9hnlwtqm5s5mkngqdqytdc0a6elquh6n70nk"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17zucl25842g99vytr9yzw0eqmql3wwpql357cx"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra16kgssn83sz92u22mmqtgmd795edtttu7apjsm9",
+      "liquidity_token": "terra1gk602sa0jwk73xlr8tpkd3fpukhfa8hjety68r"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17rwgygp5y7tx83xyclwuxu654vjt2whpwxx688"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra16ll0n5lm5j4vp94mjr0xa4tqxfpvvgx57mdtg3",
+      "liquidity_token": "terra1tqgkra60jq5jzear9e3zm6knwwzdxvwl2hn5vd"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17raumdxxxlm8smtx2pcxmqpz7qq9am4zfxzl8d"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1ylw3fvy4h5ll9tyaeuxrqngwnlqp3jtaegtjfq",
+      "liquidity_token": "terra15lnt74xvhhrz528gkhtz9xe23r77w00chktddr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1llhpkqd5enjfflt27u3jx0jcp5pdn6s9lfadx3",
+      "liquidity_token": "terra1ah6vn794y3fjvn5jvcv0pzrzky7gar3tp8zuyu"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17yjdhu7pk865t0jeswtpecukg0uw8xelzvfmdq"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1njhvhtgvteu08dpgnhve9gpa0wmcrzyf80s76t",
+      "liquidity_token": "terra1mlkgz49lqndlgjfe3m5m4et7kz258fx89re28p"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra178v546c407pdnx5rer3hu8s2c0fc924k74ymnn"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra12j29ct74f4wx0vrz54c96sl4gvz5a3k7mynzrq",
+      "liquidity_token": "terra1u7ym5zglwd7q0ppstuzaqfelhxw9p94czrcqdy"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17ggkh9upvkmeyew240lz95zcdytpd2j9m55he5"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1gg00qrm9l7ghqs2c2ey55uwtc7cvu39c799lr9",
+      "liquidity_token": "terra1esgjh8xnmnrndcctdjz6ux5khdylcmgenyyq9r"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra172qlk30wwyux37m45w5c7mkypn7ks0t0s3d0ms"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1a5pqgv432f3u25zu5q5r0t6e00pwd6xa8unwp3",
+      "liquidity_token": "terra13hcayvzgxur5f43qwauz3jsnf4j353ee9s7qq3"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra172xf4zehmdla56h2x8ergqmejg70f4zczzt74w"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra12kuvl9ljytve26q5nd5khnrw2hdkaa68sh5t0j",
+      "liquidity_token": "terra147g92kn88fhyjxgt4lut827smfgtjqngpg8873"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra172hwjglf7rsgrnwet52zqnzjhg7vjgcpm7nctn"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1670lwuaqtzw43q402anw4aj44ud9nqd87d639f",
+      "liquidity_token": "terra1u6ua0t8url95p2dh7tp6kvqp04h48dxx5njclp"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17t0uuy2cg7apfsqj4xqn6w5scxkd2ajgns9xvz"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra17sh5yr9tcfl2qsltrm2tulnlpzz0c6ufk683dc",
+      "liquidity_token": "terra153k57e8cka9mutkp5g6f0elje02qtmh75nshny"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17w68lnnp47k4zkfkpcyzu2xeu6qw576ksfpp4r"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra19luytfs7wt8l2e5fgg7del39m93sm64qsmufsy",
+      "liquidity_token": "terra1jfrngqdwqkfs25sgcmuxrlk6a7y8058purc4hx"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17jnhankdfl8vyzj6vejt7ag8uz0cjc9crkl2h7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1zz39wfyyqt4tjz7dz6p7s9c8pwmcw2xzde3xl8",
+      "liquidity_token": "terra1k5kumxd24cyvhf52r5u4ywlr3ztktj657wnf7a"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17n0sj0ed82upz3c38px5hl2zy7mestccskauva"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1xtaxvdlfjxyea7qpz37f5j3py3cyafkycgy8c5",
+      "liquidity_token": "terra1z364vxmwx7gadv0pd8ywul8k2k68rjahxq0c5w"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17nekftv2yp8n4lsex85008sphchs4t3rnfcqzf"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1n52ua9wxsak94d9zlc60jufurahfpl6s9qxzwj",
+      "liquidity_token": "terra1trw024zghdye5l5kal2nqcl4j3crg8uayk5er8"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra174tuptw39sd3s5yqq466xc5lygh9z8gp05wf4j"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra14m7prknmsyxjey7mkafl6340ckvnn6ve0uuxlr",
+      "liquidity_token": "terra1e4uxrgeezzcw33cfek64u7kq55jyn5dsartakt"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1745fzfxnd8wx5kdrf4uwgj7k0mkqk64pdrh56k"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1su2magsez6h9xwss3czd8wj6l3c8eujed09d8v",
+      "liquidity_token": "terra1shwul2pfd5x5k8am6ffpts369s533pcspjr7m5"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra174c2cy42fl7hags7cap8j4xtsmcc0ql2s8q5du"
+          }
+        }
+      ],
+      "contract_addr": "terra1uukk3m4qemzdjatzh8p0m2qrg95f2yc8wrfzav",
+      "liquidity_token": "terra13ae05947uryk5x2us5l5dgkhmedsxudnxjwfm6"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra174muj5m4c83mvtr49dm4gvf5h2zp24nzphwvmc"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1urnd4esuqwq89ylqrrh6lktp3rdaew9hqm8txc",
+      "liquidity_token": "terra19zju3mkymrhfefd9lv7mq0u9ke0xmveemuu33g"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17ktj9hq69ae9mj49dwqfzmj05t6eqlkyywukf8"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra10qnu9yudvcnm7we04xj8lu3mjrgx5lc247h0y2",
+      "liquidity_token": "terra1xra8v827ml3m6zfylvzfv5g72mj4qhdk7snchy"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17ckx25kqhwzf3fudprs78kqgp3lhpr2w74yf7t"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1r6dcz9whd2dxunau0vtp3g06n0yus9gfaq76pz",
+      "liquidity_token": "terra16rc4cgt4a70jfzlylyqu534m3c64tvklch2p0m"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17efcrd3glln324tqke56w5wgnfkfn5emz4um8j"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1z2p2vs8q95frqntrnqwkwmj9nempl83l3m699n",
+      "liquidity_token": "terra1fnr2j2cfapcuxr90z83sj0qjrtzt88sutz4cpf"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17etsw9uywcmw79st5yp4saar97z22l3np0m3zz"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1854dxe6nw9pktdd5j5ulesv74k3ztqgdx6mcxe",
+      "liquidity_token": "terra1x3ymanpm2v945c78zmhn3slw2890a6t039tt57"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra176eej9z5upauemz7wg2q6n86472xyy836v6smx"
+          }
+        }
+      ],
+      "contract_addr": "terra1n3khk8w48y8jf5cgjjhccg5dg9qua0xdkt98we",
+      "liquidity_token": "terra10zkfrqvgqvsh026ljcswe59lwh88yc5v43yc9q"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17azgr4x2gz20uquy7vdacfdgjjkgd0h9lm377v"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1sqaw3rsp5w84r5hwvcvcgweqcxlrhxl3e5a9na",
+      "liquidity_token": "terra1mn2na4umsz3e3p2ulutzy6vgy4f4rua33cyrmk"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra17ana8hvzea0q7w367dm0dw48sxwql39qekpt7g"
+          }
+        }
+      ],
+      "contract_addr": "terra1yphapr9zkd7eq60n2nux0xfldzs58z9ncs7s6f",
+      "liquidity_token": "terra146dmpuj9zyzk6a47qdfn0djup3kddey5vdpk0c"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1779kwh0aux9mesns3l7laxtu7njjpzqd7k7m3r"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1s79f53dq44l9yat4tzkh9ynk7nuutltz7z6eh4",
+      "liquidity_token": "terra1mwhuvt0rk2qvpqvj9dfn4wz7j8f2ftv7h804vz"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1lrqv79tw447kk4ham08suw7vak3a7pf9de2qx0"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1eryc869znes7ujk8usxrrhy2zru8f77478mn0e",
+      "liquidity_token": "terra16pj9ycwu7yvfwtkrew87ss2tqvr537fl2rl800"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1lrdzs5tgllwqgawtq2emuzn7snpxq87fzzl44y"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1erdxk0afwhq0hwpftndeayeqct9eluxyzt0v2e",
+      "liquidity_token": "terra1ngxra5n0awmaujstndfkg4sgczfvnplvw3ewx2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1lyppcm0cjc5nrge6hmwdkkeqeh4m9cat8nyf3e"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1wq6gntx33ty6vxhkmnzmj8svfdg6qa42pgsgmu",
+      "liquidity_token": "terra1w27n03fkrpfxwkgs6968tz3wxtfpa8fm74047j"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1l9pdkujwe6rteefdhprv5lns49cptcglffhpf3"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1294g768k3xzz9tpe2evpewrwghrqe6rtufw2lu",
+      "liquidity_token": "terra1slu9fqkt6j4z6yyst7qc4rlnrjq4jk29wz3ha7"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1l95pyqf2ahqy7c53pejt8v7nnlg060fghs2499"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1n66fcrg3hh2q36jrk8j900jx6xf72zw0thf3h7",
+      "liquidity_token": "terra1vwts232nu2r9nhaacmsnfs6fmfr6tf49yhd7s4"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1lxpjyl6k60rsyp0x7fa40s8jsl5l0d27ycmwfh"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1cvg3jjepvcxzkv5elvr3x5khk83wllvg4qygfc",
+      "liquidity_token": "terra1rkzg0jw55t78www72zu9tzqvzhzzexe86tryv2"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1lxh32h38lf8xdk6lv7k5w0ewy7gu6psy4gfmnm"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1n8jq50xnupyassyc3z4apwc33av3499v45tllv",
+      "liquidity_token": "terra1xvqs6trs4d2vca2us0f8uyc75jpf5d76d9d5dy"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1lgx3e9f6fhqda47zdyntfs07rdm5arp745mec7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1nayuuwy7mdcjtka7n9xt9gpcpldyqglt0jt5vf",
+      "liquidity_token": "terra17nwqqwfedrq50k779ulvl8da3jncj960xjylns"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1l2stn9sszzg6qwfqd6ckfa5n58hs4x5wwjaehh"
+          }
+        }
+      ],
+      "contract_addr": "terra19jjgf89q82d84fag9qqr5lyhcmctljjygt2yac",
+      "liquidity_token": "terra1uf5xpl99zm7c8jxtq4c3y32ygjufjk6x6ggrav"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ltfq7n4x383t8wjmp8ujjzrvyskk6eu4y2p3qh"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1twvmq2yfahhdpelavz94d9xhcmrfyazrn08lrz",
+      "liquidity_token": "terra1wdjsxymg424mw4sv6zmw4luqajwxa5e7qfvfxw"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ltcad0e9cgf2jgtzqwg82n9k54fre68wdddfll"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1hke7ncmglkcevsgx0txma8a02pz4npypahcc0r",
+      "liquidity_token": "terra1xtxds95gvddytcxqu5larnuvxt5gekwfxclyu2"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1lvmx8fsagy70tv0fhmfzdw9h6s3sy4prz38ugf"
+          }
+        }
+      ],
+      "contract_addr": "terra1zey9knmvs2frfrjnf4cfv4prc4ts3mrsefstrj",
+      "liquidity_token": "terra1utf3tm35qk6fkft7ltcnscwml737vfz7xghwn5"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ldrmvk4n0le7tdaxj7r8gk5kny95r6mxw3ask7"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1x8rmne82kuy2gx26r3ecxrjns97ef8ckf9exvv",
+      "liquidity_token": "terra1wnqp45zle5yq65dvevda927ver36sgvgvfu5gg"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1ld37cm20t8z3r0zvk7hx2qcfr2cdayteed8089"
+          }
+        }
+      ],
+      "contract_addr": "terra1msws3xuf0ey3l0sdt0t3rw49gjcq4nya8h3lad",
+      "liquidity_token": "terra14jaq6qur7mafha4ky8u6ct67xav4zt054p865j"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1l0rnt55mf8q87q2nqfn9un3lxnmxkhqrl939x5"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1kphghf722vxe0aq04n4erzflgcpp0pysrvtj0p",
+      "liquidity_token": "terra1ay647sah03j0zv7pn62sp46sys7gqtnawnf3u7"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1l0y8yg0s86x299nqw0p6fhh7ngex3r4phtjeuq"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1fmv3g96s4xc9nrnlkdn87vxyaydd22xsxzel5r",
+      "liquidity_token": "terra1edum55hjxu0fts7wxq5j0umjzm359fenausrup"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1lj2t6zem4kk3cf400srvhaczpv2lg8kzpy5xr5"
+          }
+        }
+      ],
+      "contract_addr": "terra18rwpsjq4pcyv2cj2555a74yykwkrn3yktktlrc",
+      "liquidity_token": "terra1erl67wndtyf2nngpy2lr0xj5z7yrustt3v2jew"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1lj0m5346vc6da9r9ljcyx7letcl3727g7wac62"
+          }
+        }
+      ],
+      "contract_addr": "terra1qm7vvqg2jh5mwkd696luhvqe4mx96e4xuk60g2",
+      "liquidity_token": "terra1xxj9nsxffy6hcc6mfq84fjfwt9k9e0n4800pgy"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1lnrphdxwfre5w7rwazzfnp0k9d4glm63t7gg70"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1cyu32h09k6djqt3a0pgljgan2vass3etl6vcng",
+      "liquidity_token": "terra1adrqsdqtnhsvadl9gzuqcrh63vyye2zdzsj64g"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1lnucwh7feutx0y8dgh3lu759a6netxx4wjzm4w"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra128s8lplqeqepy8vh55cr0rzdhe66v9h3n52qk3",
+      "liquidity_token": "terra1ekfxyvagzayn32m6jcqylzefdtjnhkcnwjvwre"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1lnav098k7vd006lz7d73mychha503pmw35la7l"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1sxxn4rxuqgxn3um6ly5lf9wsjuewrr7j8tvjg0",
+      "liquidity_token": "terra1hqj0eln43y4k4h036kddtll63lw7yvc3gz226a"
+    },
+    {
+      "asset_infos": [
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1l5lrxtwd98ylfy09fn866au6dp76gu8ywnudls"
+          }
+        }
+      ],
+      "contract_addr": "terra1ze5f2lm5clq2cdd9y2ve3lglfrq6ap8cqncld8",
+      "liquidity_token": "terra1pjgzke6h5v4nz978z3a92gqajwhn8yyh5kv4zv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1l4uygw365sgdgvasmckkd7lcawyemzn9k83lrh"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra18jkyaayc7s3an3gn6xhz9ue75pdy46zrvzwle2",
+      "liquidity_token": "terra1ldy8tjaqa9zjq6h2290ac2k40ta94e4hky8caa"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1lkszqh6duver9s9h0qfr2dcktj605km3hzfzjd"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra13kvcwhxa0ym2tpgcchk0rn0zrrl7r7w0mgv74q",
+      "liquidity_token": "terra1n9w80dcemd9uys5fjfv6detru9vcftservvj5n"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1lkjq6f2sqlqjk0crs2a7fv6m5pquhl8nuesp3j"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1rrek47kf0t968g2jcg5ww8fw58n93jkclkk4v5",
+      "liquidity_token": "terra107tg7rwfd3mjxzzev305r6qg52z0xl7yxq7s2z"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1lcs47eqhugywzrf83xhk65skmfqmxgvkqfq64g"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra19zmlnmj5pqpwvtzzgyzqurlul972myjzntsmn8",
+      "liquidity_token": "terra1aarnpmtzs2nrkpr7tylsh8zevewjgg8gjp3djr"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1lchkxy5ednukxepwxejak8xevqlmz89ukjh6hl"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1qdvgzumzmfjzyjkvr647n8el7pq05jm958f6ml",
+      "liquidity_token": "terra15rsfe8x9w3p7hl9n4ptawzw40x29t4w4h0hhnq"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1lesh2dshyf8a7wfm9fkxfrxjxc6yuyqnvspuvw"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1rjv0jjm9mzgrj3grs2p0gvyuwpuf5qt9p30wwp",
+      "liquidity_token": "terra184ufgqclvjkuycs82j0fp4xha8r6rryp7luj7g"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1l6nqyv78m3kj8v4wa7r5fr3vhp0qzrauwkx5av"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1lxug53rtdtv5c8k7alxum9pfnayzhq5mu4y880",
+      "liquidity_token": "terra1a9z6wmutvfnl7va3e85mmfu90uph0lx3jtq9m4"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1lm2lwzrpmyyt2qfhkmj7rwvh7yrh0npzpl6k7v"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra14tqq6d7n79sfjmeeqgkmewyhq65dvczgym5rhq",
+      "liquidity_token": "terra1z6x7xnsgye3gzs2mlj5v2gmyw8c35amrgu5327"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1laqzmwrpyrd5tumpx5hs638tzhle4nc42k9jak"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uusd"
+          }
+        }
+      ],
+      "contract_addr": "terra1uahrcwj3k2vjngvmr646226zg2fe2q3dguhlc5",
+      "liquidity_token": "terra172unvcgg9tys53l8m5hxedw7uey4cya39e5agc"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1mt2ytlrxhvd5c4d4fshxxs3zcus3fkdmuv4mk2"
+          }
+        },
+        {
+          "native_token": {
+            "denom": "uust"
+          }
+        }
+      ],
+      "contract_addr": "terra1j647yk8zq2hxqtpyd9acsgk34r8kmng8wkz6xd",
+      "liquidity_token": "terra19clxxmvgll47fa7wr5cqjkyl8sfn6sgeaxd65j"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1sq2ulnxng3ax08prndvwmv5rk9cy5kac2u9n02"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
+          }
+        }
+      ],
+      "contract_addr": "terra1q8c3370cwn4wu5xj33avnk2cc9f6y2mjtrjtc6",
+      "liquidity_token": "terra1xc3ya0j59yqm66pcvcx449fuaf73zh3kptd760"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1sgpvnwxmd9gmhhxzw03t7qftu00x35994denrm"
+          }
+        }
+      ],
+      "contract_addr": "terra10q2pnlvytaqnxthr6hr2ld8p8nyylx6ywxfs8a",
+      "liquidity_token": "terra15qa9g3uxx2cncpzjtmrmsq6e8jx0cten20jl7g"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1s5eczhe0h0jutf46re52x5z4r03c8hupacxmdr"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
+          }
+        }
+      ],
+      "contract_addr": "terra15asyerx0su2j3urlsn2xea0klrr5dpd75jamwj",
+      "liquidity_token": "terra1g5pe82m6hv90h2ed8esz5ldw8jpcw6y209k788"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra13xujxcrc9dqft4p9a8ls0w3j0xnzm6y2uvve8n"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
+          }
+        }
+      ],
+      "contract_addr": "terra1r0288hx3mjgx0zrpmpc8rulm6ca8jheqtwhwq5",
+      "liquidity_token": "terra1nafrz6yep84lvphmj03gryht3exa624ttgkf06"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra130fhr9jz0nylzhdvuwcpp3hne2s5qlft6hfzgv"
+          }
+        }
+      ],
+      "contract_addr": "terra1j5rqw5vtxsx7el0mptyjqhtfaqnxgg6yu90ek7",
+      "liquidity_token": "terra1kngl26kllhsmhkjjh20dz3du2fd35t75rran60"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1nagqpmyw55yjphea4rhntlfv87ugmeaj8ym756"
+          }
+        }
+      ],
+      "contract_addr": "terra1q9lnctytu3c4p5ekv3xpmyxnegxe83adeufemv",
+      "liquidity_token": "terra128pdzd65aju0q94vwj98j9lphnklgvkdpz7q83"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1lladdxhn49jz0hrvwgalu4a548txh94mcec595"
+          }
+        }
+      ],
+      "contract_addr": "terra1uz8dm5nfyrqxq0qutlx3xsgqq0ca4v7jr75zuz",
+      "liquidity_token": "terra1fvy3m6z2rsdzg5qkuuwptusw96k2ayp4fw42a5"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1nuy34nwnsh53ygpc4xprlj263cztw7vc99leh2"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra17dkr9rnmtmu7x4azrpupukvur2crnptyfvsrvr"
+          }
+        }
+      ],
+      "contract_addr": "terra1wrwf3um5vm30vpwnlpvjzgwpf5fjknt68nah05",
+      "liquidity_token": "terra1qxlp0q3z20llu0gz9c7urzw7rmlnchm23yk8xc"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15ytncdwh7yqttvvxjmw7cd2phj9a7cyldv8547"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy"
+          }
+        }
+      ],
+      "contract_addr": "terra1cqldrws5n6l8te9sh7uv86v64dffjtg3ldqksq",
+      "liquidity_token": "terra1ljmckrej9qg5a9dlz9v3axm05wa4adsyrrc7ka"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
+          }
+        }
+      ],
+      "contract_addr": "terra1t0pd5uqsqp85cgly5cvggm698asez55ked2ftu",
+      "liquidity_token": "terra1768vz98dnfxlvwjnx25r520pfevk7djfc3ymhx"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
+          }
+        }
+      ],
+      "contract_addr": "terra10dtff8drpwtfx4976m7cxwpptfy87l5p264xgy",
+      "liquidity_token": "terra16gqa7q433a2q7d6ankxz0qk4pwet53fakazqv9"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
+          }
+        }
+      ],
+      "contract_addr": "terra1hkp4hulmttwzagzphr6vczvjm46e6ryxv99nan",
+      "liquidity_token": "terra1mm72fhs0t0sxnvvdu34srcqfk4c8zgcaf2xzd3"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
+          }
+        }
+      ],
+      "contract_addr": "terra1alaaant5ykususyuv0x6k298sh8kl8qkpkuu8e",
+      "liquidity_token": "terra1668hdgce50nwxs8myp33f4ywvs6lanzxvvu9sx"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
+          }
+        }
+      ],
+      "contract_addr": "terra1w3uwnguslkntkm3wsq86zan0a6jgtgwk0wr8z8",
+      "liquidity_token": "terra1wc3c8lv6krlz2dvprvp8e3k4t330dvsn4n80p3"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1c00vskhyzdv0z63z2tyetzx2qma67n2z3vzyn0"
+          }
+        }
+      ],
+      "contract_addr": "terra1zrl9mugl97mrhtkacvws70w95sjemyxmq5ydwk",
+      "liquidity_token": "terra178lvrr8aa3fl70ar3kp9rgvny2qrnmgepa2ctw"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kp8vne240370hn722ec5sacsdluyt2j0gc5nph"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy"
+          }
+        }
+      ],
+      "contract_addr": "terra1ufl3mnqqkucdgp68zrqxwmth9yy3ja5hnjv2c0",
+      "liquidity_token": "terra16kw4vsl0wm3lt55cn4a47cz2y7d7ydsjwwfu08"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra16gx5th8mk5v62xpvgf675xj2vuaf3dg4v75ml5"
+          }
+        }
+      ],
+      "contract_addr": "terra1dcqj2agjxrc7gz3zsfqxux8js3r2rz0wumch6t",
+      "liquidity_token": "terra1h0vyhc8ttqe2swxkvwl8v75wpfpp5c3vxwdxxv"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp"
+          }
+        }
+      ],
+      "contract_addr": "terra1x8h5gan6vey5cz2xfyst74mtqsj7746fqj2hze",
+      "liquidity_token": "terra1spagsh9rgcpdgl5pj6lfyftmhtz9elugurfl92"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1cqldrws5n6l8te9sh7uv86v64dffjtg3ldqksq"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy"
+          }
+        }
+      ],
+      "contract_addr": "terra10jnjermmyfxju2apz5ms5m3hqt6dcz77lskec2",
+      "liquidity_token": "terra1cwseg0eujp5jg2n5ncsfzgeud05tez4pm9vwlc"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
+          }
+        }
+      ],
+      "contract_addr": "terra13rprqshf7dxn48v0aaztv5c7ytct6t6u7djtlw",
+      "liquidity_token": "terra19ahlx8uhyslmt8u6a6tzsugepm8a3kfemjeucl"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra1ustvnmngueq0p4jd7gfnutgvdc6ujpsjhsjd02"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1ln2z938phz0nc2wepxpzfkwp6ezn9yrz9zv9ep"
+          }
+        }
+      ],
+      "contract_addr": "terra1cmehvqwvglg08clmqn66zfuv5cuxgxwrt3jz2u",
+      "liquidity_token": "terra1z0vaks4wkehncztu2a3j2z4fj2gjsnyk2ng9xu"
+    },
+    {
+      "asset_infos": [
+        {
+          "token": {
+            "contract_addr": "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup"
+          }
+        },
+        {
+          "token": {
+            "contract_addr": "terra1u553zk43jd4rwzc53qrdrq4jc2p8rextyq09dj"
+          }
+        }
+      ],
+      "contract_addr": "terra1j3dc7eh7tus3jn476zwz9waf37w6hy5qgtjhc3",
+      "liquidity_token": "terra1k7er6xrdmyuqrsevhv9h25gxxpwl43hxmmtd82"
+    }
+  ]
+}

--- a/src/rest/useAPI.ts
+++ b/src/rest/useAPI.ts
@@ -1,3 +1,4 @@
+import v1Pairs from "constants/v1-pairs.json"
 import { useAddress, useNetwork } from "hooks"
 import {
   UAUD as VAUD,
@@ -232,6 +233,10 @@ const useAPI = (version: ApiVersion = "v2") => {
       pairs: [],
     }
     let lastPair: (NativeInfo | AssetInfo)[] | null = null
+
+    if (version === "v1") {
+      return v1Pairs
+    }
 
     try {
       const url = `${apiHost}/pairs${


### PR DESCRIPTION
## Background
- migration use v2 pair list instead of v1 pairs.

## Summary
- add v1 pairs and return when the requested API version is v1